### PR TITLE
feat: order type permissions, backdate orders, photo optionnelle mana…

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -194,12 +194,25 @@ app.use('*', (req, res) => {
   });
 });
 
+// Auto-migrations au démarrage
+async function runStartupMigrations() {
+  const db = require('./models/database');
+  try {
+    await db.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS allowed_order_types JSONB DEFAULT NULL`);
+    console.log('✅ Migration: allowed_order_types OK');
+  } catch (err) {
+    console.error('⚠️ Migration allowed_order_types:', err.message);
+  }
+}
+
 // Démarrage du serveur
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 Serveur API démarré sur le port ${PORT}`);
-  console.log(`📊 Environnement: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`🔗 URL locale: http://localhost:${PORT}`);
-  console.log(`🔗 URL réseau: http://192.168.1.184:${PORT}`);
+runStartupMigrations().then(() => {
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`🚀 Serveur API démarré sur le port ${PORT}`);
+    console.log(`📊 Environnement: ${process.env.NODE_ENV || 'development'}`);
+    console.log(`🔗 URL locale: http://localhost:${PORT}`);
+    console.log(`🔗 URL réseau: http://192.168.1.184:${PORT}`);
+  });
 });
 
 module.exports = app; 

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -63,7 +63,8 @@ class AuthController {
         user: {
           id: user.id,
           username: user.username,
-          role: user.role
+          role: user.role,
+          allowed_order_types: user.allowed_order_types || null
         },
         token: token // Include token for mobile fallback
       });
@@ -110,7 +111,8 @@ class AuthController {
         user: {
           id: req.user.id,
           username: req.user.username,
-          role: req.user.role
+          role: req.user.role,
+          allowed_order_types: req.user.allowed_order_types || null
         }
       });
 

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -8,7 +8,7 @@ class OrderController {
   // Créer une nouvelle commande
   static async createOrder(req, res) {
     try {
-      const { client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, interne } = req.body;
+      const { client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, interne, created_at } = req.body;
       
       // Debug: logger les données reçues
       console.log('🔍 Données reçues pour création de commande:', {
@@ -72,6 +72,22 @@ class OrderController {
         actualCreatedBy = req.user.id;
       }
 
+      // Vérifier que le livreur a accès à ce type de commande
+      if (req.user.role === 'LIVREUR') {
+        const orderTypesConfig = require('../config/order-types.json');
+        const allTypes = [...orderTypesConfig.coreTypes, ...orderTypesConfig.extensions.map(e => e.value)];
+        const defaultAllowed = allTypes.filter(t => t !== 'MATA');
+        const allowed = req.user.allowed_order_types || defaultAllowed;
+        if (!allowed.includes(order_type)) {
+          return res.status(403).json({
+            error: `Vous n'avez pas accès au type de commande ${order_type}`
+          });
+        }
+      }
+
+      // Only managers/admins can backdate orders
+      const finalCreatedAt = (req.user.role === 'MANAGER' || req.user.role === 'ADMIN') && created_at ? created_at : undefined;
+
       const newOrder = await Order.create({
         client_name: finalClientName,
         phone_number: finalPhoneNumber,
@@ -84,7 +100,8 @@ class OrderController {
         course_price,
         order_type,
         created_by: actualCreatedBy,
-        interne: isInterne
+        interne: isInterne,
+        created_at: finalCreatedAt
       });
 
       res.status(201).json({

--- a/backend/controllers/timesheetController.js
+++ b/backend/controllers/timesheetController.js
@@ -417,11 +417,11 @@ const startActivityForUser = async (req, res) => {
     const { user_id, date, km, scooter_id } = req.body;
     const photo = req.file;
 
-    // Validations
-    if (!user_id || !date || !km || !photo) {
+    // Validations (photo optionnelle pour managers)
+    if (!user_id || !date || !km) {
       return res.status(400).json({
         success: false,
-        message: 'ID utilisateur, date, kilométrage et photo sont requis.'
+        message: 'ID utilisateur, date et kilométrage sont requis.'
       });
     }
 
@@ -482,8 +482,14 @@ const startActivityForUser = async (req, res) => {
       }
     }
 
-    // Upload de la photo
-    const { filePath, fileName } = await uploadTimesheetPhoto(photo, user_id, date, 'start');
+    // Upload de la photo (optionnelle pour managers)
+    let filePath = null;
+    let fileName = null;
+    if (photo) {
+      const uploaded = await uploadTimesheetPhoto(photo, user_id, date, 'start');
+      filePath = uploaded.filePath;
+      fileName = uploaded.fileName;
+    }
 
     // Créer le pointage
     let timesheet;
@@ -540,11 +546,11 @@ const endActivityForUser = async (req, res) => {
     const { timesheet_id, km } = req.body;
     const photo = req.file;
 
-    // Validations
-    if (!timesheet_id || !km || !photo) {
+    // Validations (photo optionnelle pour managers)
+    if (!timesheet_id || !km) {
       return res.status(400).json({
         success: false,
-        message: 'ID du pointage, kilométrage et photo sont requis.'
+        message: 'ID du pointage et kilométrage sont requis.'
       });
     }
 
@@ -591,8 +597,14 @@ const endActivityForUser = async (req, res) => {
       });
     }
 
-    // Upload de la photo
-    const { filePath, fileName } = await uploadTimesheetPhoto(photo, timesheet.user_id, timesheet.date, 'end');
+    // Upload de la photo (optionnelle pour managers)
+    let filePath = null;
+    let fileName = null;
+    if (photo) {
+      const uploaded = await uploadTimesheetPhoto(photo, timesheet.user_id, timesheet.date, 'end');
+      filePath = uploaded.filePath;
+      fileName = uploaded.fileName;
+    }
 
     // Mettre à jour le pointage
     const updatedTimesheet = await Timesheet.updateEnd(timesheet.id, {

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -150,6 +150,15 @@ class UserController {
         });
       }
 
+      // Valider allowed_order_types si fourni
+      if (updates.allowed_order_types !== undefined) {
+        if (updates.allowed_order_types === null || (Array.isArray(updates.allowed_order_types) && updates.allowed_order_types.length === 0)) {
+          updates.allowed_order_types = null;
+        } else if (!Array.isArray(updates.allowed_order_types)) {
+          return res.status(400).json({ error: 'allowed_order_types doit être un tableau' });
+        }
+      }
+
       const updatedUser = await User.update(id, updates);
 
       res.json({

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -1,4 +1,11 @@
 const { body, param, query, validationResult } = require('express-validator');
+const orderTypesConfig = require('../config/order-types.json');
+
+// Build valid order types from config (case-insensitive matching)
+const validOrderTypes = [
+  ...orderTypesConfig.coreTypes,
+  ...orderTypesConfig.extensions.map(e => e.value)
+];
 
 // Middleware pour gérer les erreurs de validation
 const handleValidationErrors = (req, res, next) => {
@@ -173,9 +180,10 @@ const validateOrderCreation = [
     .withMessage('Le montant doit être un nombre positif inférieur à 1 000 000'),
     
   body('order_type')
-    .isIn(['MATA', 'MLC', 'YANGO', 'KEUR_BALLI', 'AUTRE'])
-    .withMessage('Le type de commande doit être MATA, MLC, Yango, Keur Balli ou Autre'),
-  
+    .customSanitizer(val => typeof val === 'string' ? val.toUpperCase() : val)
+    .isIn(validOrderTypes)
+    .withMessage(`Le type de commande doit être ${validOrderTypes.join(', ')}`),
+
   body('adresse_source')
     .if(body('order_type').custom(val => val === 'MLC' || val === 'AUTRE'))
     .notEmpty().withMessage('Adresse source requise pour ce type de commande')
@@ -188,7 +196,19 @@ const validateOrderCreation = [
     .if(body('order_type').equals('MATA'))
     .notEmpty().withMessage('Le point de vente est obligatoire pour MATA')
     .isIn(['O.Foire', 'Mbao', 'Keur Massar','Sacre Coeur']).withMessage('Point de vente invalide'),
-  
+
+  body('created_at')
+    .optional({ values: 'falsy' })
+    .isISO8601().withMessage('La date doit être au format valide')
+    .custom(val => {
+      const date = new Date(val);
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+      if (date >= tomorrow) throw new Error('La date ne peut pas être dans le futur');
+      return true;
+    }),
+
   handleValidationErrors
 ];
 
@@ -235,8 +255,9 @@ const validateOrderUpdate = [
     
   body('order_type')
     .optional()
-    .isIn(['MATA', 'MLC', 'AUTRE'])
-    .withMessage('Le type de commande doit être MATA, MLC ou AUTRE'),
+    .customSanitizer(val => typeof val === 'string' ? val.toUpperCase() : val)
+    .isIn(validOrderTypes)
+    .withMessage(`Le type de commande doit être ${validOrderTypes.join(', ')}`),
     
   body('commentaire')
     .optional()

--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -22,18 +22,24 @@ class Order {
   }
 
   // Créer une nouvelle commande
-  static async create({ client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, subscription_id, interne }) {
+  static async create({ client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, subscription_id, interne, created_at }) {
     const id = uuidv4();
-    
+
+    const columns = 'id, client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, subscription_id, interne' + (created_at ? ', created_at' : '');
+    const placeholders = '$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14' + (created_at ? ', $15' : '');
+
     const query = `
-      INSERT INTO orders (id, client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount, course_price, order_type, created_by, subscription_id, interne)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      INSERT INTO orders (${columns})
+      VALUES (${placeholders})
       RETURNING *
     `;
-    
-    const result = await db.query(query, [
+
+    const params = [
       id, client_name, phone_number, adresse_source, adresse_destination, point_de_vente, address, description, amount || null, course_price || 0, order_type, created_by, subscription_id || null, interne || false
-    ]);
+    ];
+    if (created_at) params.push(created_at);
+
+    const result = await db.query(query, params);
     
     return new Order(result.rows[0]);
   }

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -11,6 +11,7 @@ class User {
     this.is_active = data.is_active;
     this.created_at = data.created_at;
     this.updated_at = data.updated_at;
+    this.allowed_order_types = data.allowed_order_types || null;
   }
 
   // Créer un nouvel utilisateur
@@ -93,7 +94,7 @@ class User {
 
   // Mettre à jour un utilisateur
   static async update(id, updates) {
-    const allowedFields = ['username', 'role', 'is_active'];
+    const allowedFields = ['username', 'role', 'is_active', 'allowed_order_types'];
     const setClause = [];
     const values = [];
     let paramIndex = 1;
@@ -102,7 +103,8 @@ class User {
     for (const [key, value] of Object.entries(updates)) {
       if (allowedFields.includes(key)) {
         setClause.push(`${key} = $${paramIndex}`);
-        values.push(value);
+        // JSONB columns need JSON.stringify
+        values.push(key === 'allowed_order_types' && value !== null ? JSON.stringify(value) : value);
         paramIndex++;
       }
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -558,6 +558,12 @@
                     </select>
                 </div>
 
+                <div class="form-group" id="order-date-group" style="display: none;">
+                    <label for="order-date">Date de la commande</label>
+                    <input type="date" id="order-date" name="created_at">
+                    <small style="color: #666;">Laisser vide pour la date du jour</small>
+                </div>
+
                 <!-- Nouveau groupe pour les zones MLC sans abonnement -->
                 <div class="form-group" id="mlc-zone-group" style="display: none;">
                     <label for="mlc-zone">Sélectionner la zone de livraison *</label>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -984,9 +984,36 @@ class PageManager {
             } catch (error) {
               ToastManager.error('Erreur lors du chargement des livreurs');
             }
+          // Affichage du champ date pour managers/admins
+            const orderDateGroup = document.getElementById('order-date-group');
+            if (orderDateGroup) orderDateGroup.style.display = 'block';
           } else {
             livreurGroup.style.display = 'none';
+            const orderDateGroup = document.getElementById('order-date-group');
+            if (orderDateGroup) orderDateGroup.style.display = 'none';
           }
+
+          // Population dynamique du dropdown type de commande (filtré par permissions)
+          (function populateOrderTypeDropdownFiltered() {
+            const sel = document.getElementById('order-type');
+            if (!sel) return;
+            const currentVal = sel.value;
+            sel.innerHTML = '<option value="">Sélectionner un type</option>';
+            const allOptions = getOrderTypeOptions();
+            let options = allOptions;
+            if (AppState.user && AppState.user.role === 'LIVREUR') {
+              const defaultAllowed = allOptions.filter(t => t.value !== 'MATA').map(t => t.value);
+              const allowed = AppState.user.allowed_order_types || defaultAllowed;
+              options = allOptions.filter(t => allowed.includes(t.value));
+            }
+            options.forEach(({ label, value }) => {
+              const opt = document.createElement('option');
+              opt.value = value;
+              opt.textContent = label;
+              if (value === currentVal) opt.selected = true;
+              sel.appendChild(opt);
+            });
+          })();
           break;
         case 'orders':
           await OrderManager.loadOrders();
@@ -5535,13 +5562,26 @@ class LivreurManager {
         return;
       }
 
+      // Générer les checkboxes de types de commandes depuis order-types.json
+      const allTypes = getOrderTypeOptions();
+      const defaultAllowed = allTypes.filter(t => t.value !== 'MATA').map(t => t.value);
+      const currentAllowed = livreur.allowed_order_types || defaultAllowed;
+
+      const orderTypeCheckboxes = allTypes.map(t => {
+        const checked = currentAllowed.includes(t.value) ? 'checked' : '';
+        return `<label style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;margin:4px;border-radius:20px;cursor:pointer;background:${checked ? '#e8f5e9' : '#f5f5f5'};border:1px solid ${checked ? '#4caf50' : '#ddd'};font-size:14px;white-space:nowrap;">
+          <input type="checkbox" name="allowed_order_types" value="${t.value}" ${checked} style="margin:0;">
+          ${Utils.escapeHtml(t.label)}
+        </label>`;
+      }).join('');
+
       const content = `
         <form id="edit-livreur-form">
           <div class="form-group">
             <label for="edit-livreur-username">Nom d'utilisateur *</label>
             <input type="text" id="edit-livreur-username" name="username" value="${Utils.escapeHtml(livreur.username)}" required>
           </div>
-          
+
           <div class="form-group">
             <label for="edit-livreur-active">Statut</label>
             <select id="edit-livreur-active" name="is_active">
@@ -5549,7 +5589,14 @@ class LivreurManager {
               <option value="false" ${!livreur.is_active ? 'selected' : ''}>Inactif</option>
             </select>
           </div>
-          
+
+          <div class="form-group">
+            <label>Types de courses autorisés</label>
+            <div style="display:flex;flex-wrap:wrap;gap:2px;padding:8px 4px;">
+              ${orderTypeCheckboxes}
+            </div>
+          </div>
+
           <div class="form-actions">
             <button type="submit" class="btn btn-primary">Sauvegarder</button>
             <button type="button" class="btn btn-secondary modal-cancel-btn">Annuler</button>
@@ -5566,10 +5613,12 @@ class LivreurManager {
 
       document.getElementById('edit-livreur-form').addEventListener('submit', async (e) => {
         e.preventDefault();
-        
+
         const formData = new FormData(e.target);
-        const userData = Object.fromEntries(formData.entries());
-        userData.is_active = userData.is_active === 'true';
+        const userData = {};
+        userData.username = formData.get('username');
+        userData.is_active = formData.get('is_active') === 'true';
+        userData.allowed_order_types = formData.getAll('allowed_order_types');
 
         try {
           await ApiClient.updateUser(livreurId, userData);
@@ -6855,6 +6904,11 @@ class App {
         }
       }
       
+      // Supprimer created_at si vide (laisser le serveur utiliser NOW())
+      if (!orderData.created_at) {
+        delete orderData.created_at;
+      }
+
       // Convertir les montants en nombres
       if (orderData.course_price) {
         orderData.course_price = parseFloat(orderData.course_price);
@@ -7288,7 +7342,15 @@ class App {
       const sel = document.getElementById('order-type');
       if (!sel) return;
       sel.innerHTML = '<option value="">Sélectionner un type</option>';
-      getOrderTypeOptions().forEach(({ label, value }) => {
+      const allOptions = getOrderTypeOptions();
+      // Pour les livreurs, filtrer selon leurs types autorisés
+      let options = allOptions;
+      if (AppState.user && AppState.user.role === 'LIVREUR') {
+        const defaultAllowed = allOptions.filter(t => t.value !== 'MATA').map(t => t.value);
+        const allowed = AppState.user.allowed_order_types || defaultAllowed;
+        options = allOptions.filter(t => allowed.includes(t.value));
+      }
+      options.forEach(({ label, value }) => {
         const opt = document.createElement('option');
         opt.value = value;
         opt.textContent = label;

--- a/frontend/js/pointage.js
+++ b/frontend/js/pointage.js
@@ -1197,8 +1197,8 @@ async function submitPointForUser(e) {
   const timesheetId = document.getElementById('point-timesheet-id')?.value;
   const scooterId = document.getElementById('point-scooter-id')?.value;
 
-  if (!userId || !date || !km || !photoFile) {
-    showNotification('Veuillez remplir tous les champs et ajouter une photo', 'error');
+  if (!userId || !date || !km) {
+    showNotification('Veuillez remplir tous les champs obligatoires', 'error');
     return;
   }
 
@@ -1212,7 +1212,9 @@ async function submitPointForUser(e) {
   formData.append('user_id', userId);
   formData.append('date', date);
   formData.append('km', km);
-  formData.append('photo', photoFile);
+  if (photoFile) {
+    formData.append('photo', photoFile);
+  }
   
   // Ajouter scooter_id pour le début, timesheet_id pour la fin
   if (type === 'start' && scooterId) {

--- a/frontend/js/timesheets-manager.js
+++ b/frontend/js/timesheets-manager.js
@@ -613,9 +613,9 @@ const TimesheetsManagerView = (() => {
     const timesheetId = document.getElementById('point-timesheet-id')?.value;
     const scooterId = document.getElementById('point-scooter-id')?.value;
 
-    // Validations
-    if (!userId || !date || !km || !photoFile) {
-      showNotification('Veuillez remplir tous les champs et ajouter une photo', 'error');
+    // Validations (photo optionnelle pour managers)
+    if (!userId || !date || !km) {
+      showNotification('Veuillez remplir tous les champs obligatoires', 'error');
       return;
     }
 
@@ -630,7 +630,9 @@ const TimesheetsManagerView = (() => {
     formData.append('user_id', userId);
     formData.append('date', date);
     formData.append('km', km);
-    formData.append('photo', photoFile);
+    if (photoFile) {
+      formData.append('photo', photoFile);
+    }
     
     // Ajouter scooter_id pour le début, timesheet_id pour la fin
     if (type === 'start' && scooterId) {


### PR DESCRIPTION
…gers

- Fix order_type validation for YANGO/KEUR_BALLI on update (was only allowing MATA/MLC/AUTRE)
- Make validation dynamic from order-types.json with case-insensitive matching
- Allow managers to backdate orders with a date picker on the create form
- Make photo optional for managers in pointage (start/end for user)
- Add per-livreur order type permissions (allowed_order_types JSONB column)
- Auto-migration at startup for the new column
- Edit livreur modal with checkboxes to configure allowed order types
- Filter order type dropdown for livreurs based on their permissions
- Default: livreurs have access to all types except MATA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify custom order dates when creating orders (with role-based restrictions)
  * Delivery drivers can only create orders for their assigned order types
  * Photos are now optional when recording timesheet entries
  * Administrators can manage allowed order types per delivery driver
  * Dynamic order type filtering based on user permissions

* **Chores**
  * Database schema update to support user order type permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->