### PR TITLE
feat: configurable default prices per order type with history

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -31,6 +31,7 @@ const timesheetRoutes = require('./routes/timesheets');
 const versementsRoutes = require('./routes/versements');
 const mlcZonesRoutes = require('./routes/mlcZones');
 const rankingRoutes = require('./routes/ranking');
+const orderTypePricesRoutes = require('./routes/orderTypePrices');
 
 const app = express();
 const PORT = process.env.BACKEND_PORT || 4000; 
@@ -119,6 +120,7 @@ app.use('/api/v1/clients', clientCreditsRoutes);
 app.use('/api/v1/timesheets', timesheetRoutes);
 app.use('/api/v1/versements', versementsRoutes);
 app.use('/api/v1/mlc-zones', mlcZonesRoutes);
+app.use('/api/v1/order-type-prices', orderTypePricesRoutes);
 app.use('/api/v1/ranking', rankingRoutes);
 app.use('/api/v1', attachmentRoutes);
 app.use('/api/external', externalRoutes);
@@ -250,6 +252,61 @@ async function runStartupMigrations() {
     console.log('✅ Migration: mlc_zones OK');
   } catch (err) {
     console.error('⚠️ Migration mlc_zones:', err.message);
+  }
+
+  // Table order_type_prices : prix par défaut des types de commandes, avec historisation par date d'effet
+  try {
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS order_type_prices (
+        id SERIAL PRIMARY KEY,
+        order_type VARCHAR(50) NOT NULL,
+        default_price INTEGER,
+        hors_zone_supplement INTEGER,
+        effective_from DATE NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW(),
+        created_by UUID,
+        comment TEXT
+      )
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_order_type_prices_lookup
+      ON order_type_prices (order_type, effective_from DESC)
+    `);
+    // Sécurité : si une version antérieure a créé created_by en INTEGER, le convertir en UUID
+    // (users.id est un UUID). Sans valeurs non-NULL, la conversion est triviale.
+    await db.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'order_type_prices' AND column_name = 'created_by' AND data_type <> 'uuid'
+        ) THEN
+          ALTER TABLE order_type_prices ALTER COLUMN created_by TYPE UUID USING NULLIF(created_by::text, '')::uuid;
+        END IF;
+      END $$;
+    `);
+    // Seed si la table est vide : reprend les valeurs actuelles avec une date d'effet très ancienne
+    // pour que toutes les commandes existantes conservent la base MATA = 1000 dans les rapports.
+    const { rows } = await db.query('SELECT COUNT(*) FROM order_type_prices');
+    if (parseInt(rows[0].count) === 0) {
+      const orderTypesConfig = require('./config/order-types.json');
+      const allTypes = [...orderTypesConfig.coreTypes, ...orderTypesConfig.extensions.map(e => e.value)];
+      for (const type of allTypes) {
+        // Seul MATA a un prix par défaut fixe (1000) et un supplément hors-zone (1000).
+        // Les autres types restent en saisie libre / pilotés par les zones (NULL).
+        const defaultPrice = type === 'MATA' ? 1000 : null;
+        const horsZoneSupplement = type === 'MATA' ? 1000 : null;
+        await db.query(
+          `INSERT INTO order_type_prices (order_type, default_price, hors_zone_supplement, effective_from, comment)
+           VALUES ($1, $2, $3, '2000-01-01', 'Valeur initiale (seed)')`,
+          [type, defaultPrice, horsZoneSupplement]
+        );
+      }
+      console.log('✅ Migration: order_type_prices seeded');
+    }
+    console.log('✅ Migration: order_type_prices OK');
+  } catch (err) {
+    console.error('⚠️ Migration order_type_prices:', err.message);
   }
 
   // Mise à jour contrainte users_role_check pour inclure READONLY

--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -497,8 +497,8 @@ class Order {
         SUM(COALESCE(o.course_price, 0)) as total_amount,
         SUM(
           CASE 
-            -- MATA hors zone : supplément au-dessus du prix de base (1000 FCFA)
-            WHEN o.order_type = 'MATA' AND o.course_price > 1000 THEN o.course_price - 1000
+            -- MATA hors zone : supplément au-dessus du prix de base en vigueur à la date de la commande
+            WHEN o.order_type = 'MATA' AND o.course_price > COALESCE(mp.default_price, 1000) THEN o.course_price - COALESCE(mp.default_price, 1000)
             -- MLC avec abonnement : supplément au-dessus du prix unitaire de l'abonnement
             WHEN o.order_type = 'MLC' AND o.subscription_id IS NOT NULL AND s.id IS NOT NULL THEN 
               GREATEST(0, o.course_price - (s.price / s.total_deliveries))
@@ -507,8 +507,8 @@ class Order {
         ) as total_supplements,
         STRING_AGG(
           DISTINCT CASE 
-            WHEN o.order_type = 'MATA' AND o.course_price > 1000 THEN 
-              CONCAT('MATA Hors zone (+', ROUND(o.course_price - 1000), ')')
+            WHEN o.order_type = 'MATA' AND o.course_price > COALESCE(mp.default_price, 1000) THEN
+              CONCAT('MATA Hors zone (+', ROUND(o.course_price - COALESCE(mp.default_price, 1000)), ')')
             WHEN o.order_type = 'MLC' AND o.subscription_id IS NOT NULL AND s.id IS NOT NULL AND o.course_price > (s.price / s.total_deliveries) THEN 
               CONCAT('MLC Extra (+', ROUND(o.course_price - (s.price / s.total_deliveries)), ')')
             ELSE NULL
@@ -516,7 +516,7 @@ class Order {
         ) as supplement_types,
         COUNT(
           CASE 
-            WHEN o.order_type = 'MATA' AND o.course_price > 1000 THEN 1
+            WHEN o.order_type = 'MATA' AND o.course_price > COALESCE(mp.default_price, 1000) THEN 1
             WHEN o.order_type = 'MLC' AND o.subscription_id IS NOT NULL AND s.id IS NOT NULL AND o.course_price > (s.price / s.total_deliveries) THEN 1
             ELSE NULL
           END
@@ -524,6 +524,13 @@ class Order {
       FROM orders o
       JOIN users u ON o.created_by = u.id
       LEFT JOIN subscriptions s ON o.subscription_id = s.id
+      LEFT JOIN LATERAL (
+        SELECT default_price
+        FROM order_type_prices otp
+        WHERE otp.order_type = 'MATA' AND otp.effective_from <= o.created_at::date
+        ORDER BY otp.effective_from DESC, otp.id DESC
+        LIMIT 1
+      ) mp ON true
       WHERE TO_CHAR(o.created_at, 'YYYY-MM') = $1
         AND u.role = 'LIVREUR' AND u.is_active = true
       GROUP BY TO_CHAR(o.created_at, 'YYYY-MM-DD'), u.username,

--- a/backend/routes/orderTypePrices.js
+++ b/backend/routes/orderTypePrices.js
@@ -1,0 +1,128 @@
+const express = require('express');
+const router = express.Router();
+const { authenticateToken, requireManagerOrAdmin } = require('../middleware/auth');
+const db = require('../models/database');
+const orderTypesConfig = require('../config/order-types.json');
+
+// Liste des types de commandes valides (depuis order-types.json)
+const validOrderTypes = [
+  ...orderTypesConfig.coreTypes,
+  ...orderTypesConfig.extensions.map(e => e.value)
+];
+
+// Normalise une valeur de prix : '' / null / undefined -> null (champ libre), sinon nombre
+function normalizePrice(value) {
+  if (value === '' || value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+// GET /api/v1/order-type-prices/current
+// Prix courants (un par type) pour pré-remplir les formulaires. Public : valeurs non sensibles,
+// et le frontend charge cette config au chargement de la page (avant login), comme les autres /config.
+router.get('/current', async (req, res) => {
+  try {
+    const { rows } = await db.query(`
+      SELECT order_type, default_price, hors_zone_supplement,
+             TO_CHAR(effective_from, 'YYYY-MM-DD') AS effective_from
+      FROM (
+        SELECT DISTINCT ON (order_type)
+          order_type, default_price, hors_zone_supplement, effective_from, id
+        FROM order_type_prices
+        WHERE effective_from <= CURRENT_DATE
+        ORDER BY order_type, effective_from DESC, id DESC
+      ) t
+    `);
+    const current = {};
+    rows.forEach(r => {
+      current[r.order_type] = {
+        default_price: r.default_price,
+        hors_zone_supplement: r.hors_zone_supplement,
+        effective_from: r.effective_from
+      };
+    });
+    res.json({ current });
+  } catch (err) {
+    console.error('Erreur GET order-type-prices/current:', err);
+    res.status(500).json({ error: 'Erreur lors du chargement des prix' });
+  }
+});
+
+// GET /api/v1/order-type-prices/history
+// Historique complet des changements (admin/manager).
+router.get('/history', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { rows } = await db.query(`
+      SELECT otp.id, otp.order_type, otp.default_price, otp.hors_zone_supplement,
+             TO_CHAR(otp.effective_from, 'YYYY-MM-DD') AS effective_from,
+             otp.created_at, otp.comment,
+             u.username AS created_by_username
+      FROM order_type_prices otp
+      LEFT JOIN users u ON otp.created_by = u.id
+      ORDER BY otp.order_type ASC, otp.effective_from DESC, otp.id DESC
+    `);
+    res.json({ history: rows });
+  } catch (err) {
+    console.error('Erreur GET order-type-prices/history:', err);
+    res.status(500).json({ error: 'Erreur lors du chargement de l\'historique' });
+  }
+});
+
+// POST /api/v1/order-type-prices
+// Enregistre un changement de prix (admin/manager). Append-only : chaque changement crée une
+// nouvelle ligne datée (effective_from), ce qui préserve l'historique et les rapports passés.
+router.post('/', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { order_type, default_price, hors_zone_supplement, effective_from, comment } = req.body;
+
+    if (!order_type || !validOrderTypes.includes(order_type)) {
+      return res.status(400).json({ error: `Type de commande invalide : ${order_type}` });
+    }
+
+    const dp = normalizePrice(default_price);
+    const hzs = normalizePrice(hors_zone_supplement);
+    if (Number.isNaN(dp) || (dp !== null && dp < 0)) {
+      return res.status(400).json({ error: 'Le prix par défaut doit être un nombre positif, ou vide' });
+    }
+    if (Number.isNaN(hzs) || (hzs !== null && hzs < 0)) {
+      return res.status(400).json({ error: 'Le supplément hors-zone doit être un nombre positif, ou vide' });
+    }
+
+    // Date d'effet : par défaut aujourd'hui. Une date future planifie le changement.
+    let eff = effective_from;
+    if (!eff) {
+      eff = new Date().toISOString().slice(0, 10);
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(eff)) {
+      return res.status(400).json({ error: 'La date d\'effet doit être au format AAAA-MM-JJ' });
+    }
+
+    const { rows } = await db.query(
+      `INSERT INTO order_type_prices (order_type, default_price, hors_zone_supplement, effective_from, created_by, comment)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [order_type, dp, hzs, eff, req.user.id, comment || null]
+    );
+    res.status(201).json({ price: rows[0] });
+  } catch (err) {
+    console.error('Erreur POST order-type-prices:', err);
+    res.status(500).json({ error: 'Erreur lors de l\'enregistrement du prix' });
+  }
+});
+
+// DELETE /api/v1/order-type-prices/:id
+// Supprime une entrée d'historique (admin/manager) — pour corriger une saisie erronée.
+// Attention : supprimer une entrée déjà appliquée modifie les rapports concernés.
+router.delete('/:id', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await db.query('DELETE FROM order_type_prices WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Entrée non trouvée' });
+    }
+    res.json({ message: 'Entrée supprimée' });
+  } catch (err) {
+    console.error('Erreur DELETE order-type-prices:', err);
+    res.status(500).json({ error: 'Erreur lors de la suppression' });
+  }
+});
+
+module.exports = router;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,6 +106,10 @@
                 <span class="icon">📍</span>
                 <span class="text">Zones MLC</span>
             </button>
+            <button class="nav-item hidden" id="nav-order-type-prices" data-page="order-type-prices">
+                <span class="icon">🏷️</span>
+                <span class="text">Prix des commandes</span>
+            </button>
             <button class="nav-item" data-page="ranking">
                 <span class="icon">🏆</span>
                 <span class="text">Classement</span>
@@ -1208,6 +1212,19 @@
             </div>
             <p style="color:#6c757d;margin:-20px 0 24px 4px;">Configurez les zones de livraison et leurs tarifs. Les livreurs verront ces zones lors de la creation d'une commande MLC.</p>
             <div id="mlc-zones-list">
+                <p style="text-align:center;padding:40px;color:#6c757d;">Chargement...</p>
+            </div>
+        </div>
+
+        <div id="order-type-prices-page" class="page">
+            <div class="page-header">
+                <h2>🏷️ Prix des commandes</h2>
+                <button class="btn btn-primary" id="add-price-change-btn" style="border-radius:10px;padding:10px 24px;font-weight:600;font-size:14px;display:flex;align-items:center;gap:8px;">
+                    <span style="font-size:18px;">+</span> Changer un prix
+                </button>
+            </div>
+            <p style="color:#6c757d;margin:-20px 0 24px 4px;">Prix par defaut pre-rempli a la creation d'une commande, par type. Chaque changement est date et historise : les rapports des mois passes conservent l'ancien prix.</p>
+            <div id="order-type-prices-list">
                 <p style="text-align:center;padding:40px;color:#6c757d;">Chargement...</p>
             </div>
         </div>

--- a/frontend/js/commandes-en-cours.js
+++ b/frontend/js/commandes-en-cours.js
@@ -482,7 +482,7 @@ async function prendreLivraison(id) {
       source_address: commande.point_vente, // Point de vente = adresse source
       destination_address: commande.client_adresse,
       point_vente: commande.point_vente, // Point de vente pour le dropdown
-      course_price: 1000, // Prix standard d'une course MATA
+      course_price: (window.getDefaultCoursePrice && window.getDefaultCoursePrice('MATA') != null ? window.getDefaultCoursePrice('MATA') : 1000), // Prix par défaut MATA (config)
       basket_amount: commande.total, // Montant du panier = total des articles
       comment: description,
       commande_en_cours_id: id // Pour marquer comme livrée après création

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -73,6 +73,40 @@ async function loadPointsDeVenteConfig() {
   }
 }
 
+// ===== CONFIGURATION DES PRIX PAR DÉFAUT DES TYPES DE COMMANDES =====
+// Prix courants chargés depuis la table order_type_prices (avec historisation par date d'effet)
+window.ORDER_TYPE_PRICES_CONFIG = null;
+
+async function loadOrderTypePricesConfig() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/order-type-prices/current`);
+    if (!res.ok) throw new Error('Erreur chargement config prix');
+    const data = await res.json();
+    window.ORDER_TYPE_PRICES_CONFIG = data.current || {};
+  } catch (e) {
+    // Fallback : comportement historique (MATA = 1000, supplément hors-zone = 1000)
+    window.ORDER_TYPE_PRICES_CONFIG = {
+      MATA: { default_price: 1000, hors_zone_supplement: 1000 }
+    };
+  }
+}
+
+// Prix par défaut à pré-remplir pour un type de commande (null = champ libre / non configuré)
+function getDefaultCoursePrice(orderType) {
+  const cfg = window.ORDER_TYPE_PRICES_CONFIG || {};
+  const entry = cfg[orderType];
+  return entry && entry.default_price != null ? Number(entry.default_price) : null;
+}
+window.getDefaultCoursePrice = getDefaultCoursePrice;
+
+// Supplément hors-zone pour MATA (fallback 1000 si non configuré)
+function getMataHorsZoneSupplement() {
+  const cfg = window.ORDER_TYPE_PRICES_CONFIG || {};
+  const entry = cfg['MATA'];
+  return entry && entry.hors_zone_supplement != null ? Number(entry.hors_zone_supplement) : 1000;
+}
+window.getMataHorsZoneSupplement = getMataHorsZoneSupplement;
+
 // Remplit tous les <select data-pdv-select> avec les points de vente
 function populatePointsDeVenteSelects() {
   const config = window.POINTS_DE_VENTE_CONFIG;
@@ -847,6 +881,23 @@ class ApiClient {
     return this.request(`/mlc-zones/${id}`, { method: 'DELETE' });
   }
 
+  // Prix par défaut des types de commandes (avec historisation)
+  static async getCurrentOrderTypePrices() {
+    return this.request('/order-type-prices/current');
+  }
+
+  static async getOrderTypePriceHistory() {
+    return this.request('/order-type-prices/history');
+  }
+
+  static async createOrderTypePrice(data) {
+    return this.request('/order-type-prices', { method: 'POST', body: JSON.stringify(data) });
+  }
+
+  static async deleteOrderTypePrice(id) {
+    return this.request(`/order-type-prices/${id}`, { method: 'DELETE' });
+  }
+
   static async createUser(userData) {
     return this.request('/users', {
       method: 'POST',
@@ -1293,6 +1344,11 @@ class PageManager {
             await MlcZonesManager.loadZones();
           }
           break;
+        case 'order-type-prices':
+          if (AppState.user && (AppState.user.role === 'MANAGER' || AppState.user.role === 'ADMIN')) {
+            await OrderTypePricesManager.loadPrices();
+          }
+          break;
         case 'ranking':
           RankingManager.init();
           await RankingManager.loadRanking();
@@ -1480,6 +1536,18 @@ class AuthManager {
       if (navMlcZones) {
         navMlcZones.classList.remove('hidden');
         navMlcZones.style.display = 'flex';
+      }
+
+      // Affichage du menu Prix des commandes : Manager/Admin uniquement (pas READONLY)
+      const navOrderTypePrices = document.getElementById('nav-order-type-prices');
+      if (navOrderTypePrices) {
+        if (AppState.user.role === 'MANAGER' || AppState.user.role === 'ADMIN') {
+          navOrderTypePrices.classList.remove('hidden');
+          navOrderTypePrices.style.display = 'flex';
+        } else {
+          navOrderTypePrices.classList.add('hidden');
+          navOrderTypePrices.style.display = 'none';
+        }
       }
       
       // Affichage des menus GPS pour managers/admins
@@ -4651,7 +4719,7 @@ class OrderManager {
           </div>
           <div class="form-group" id="edit-course-price-group" style="display: ${order.order_type ? 'block' : 'none'};">
             <label for="edit-course-price">Prix de la course (FCFA)</label>
-            <input type="number" id="edit-course-price" name="course_price" step="0.01" min="0" value="${order.course_price || (order.order_type === 'MATA' ? 1000 : '')}" ${order.order_type === 'MATA' ? 'readonly' : ''}>
+            <input type="number" id="edit-course-price" name="course_price" step="0.01" min="0" value="${order.course_price || (order.order_type === 'MATA' ? (getDefaultCoursePrice('MATA') ?? 1000) : '')}" ${order.order_type === 'MATA' ? 'readonly' : ''}>
           </div>
           <div class="form-group" id="edit-amount-group" style="display: ${order.order_type === 'MATA' ? 'block' : 'none'};">
             <label for="edit-amount">Montant du panier (FCFA)</label>
@@ -6967,6 +7035,228 @@ class MlcZonesManager {
   }
 }
 
+// ===== GESTIONNAIRE DES PRIX PAR DÉFAUT DES TYPES DE COMMANDES =====
+class OrderTypePricesManager {
+  // Libellé lisible d'un type (depuis order-types.json)
+  static labelFor(value) {
+    const cfg = window.ORDER_TYPES_CONFIG;
+    if (!cfg) return value;
+    if ((cfg.coreTypes || []).includes(value)) return value;
+    const ext = (cfg.extensions || []).find(e => e.value === value);
+    return ext ? ext.label : value;
+  }
+
+  // Liste de tous les types de commandes configurables
+  static allTypes() {
+    const cfg = window.ORDER_TYPES_CONFIG;
+    if (!cfg) return ['MATA', 'MLC'];
+    return [...(cfg.coreTypes || []), ...((cfg.extensions || []).map(e => e.value))];
+  }
+
+  static fmtPrice(v) {
+    if (v === null || v === undefined) return '<span style="color:#adb5bd;">Saisie libre</span>';
+    return Number(v).toLocaleString('fr-FR') + ' FCFA';
+  }
+
+  // Formate une date 'YYYY-MM-DD' en 'JJ/MM/AAAA' sans passer par new Date() (évite les décalages de fuseau)
+  static fmtDate(ymd) {
+    if (!ymd) return '—';
+    const s = String(ymd).slice(0, 10);
+    const parts = s.split('-');
+    return (parts.length === 3) ? `${parts[2]}/${parts[1]}/${parts[0]}` : s;
+  }
+
+  static async loadPrices() {
+    const container = document.getElementById('order-type-prices-list');
+    if (!container) return;
+
+    const canEdit = AppState.user && (AppState.user.role === 'MANAGER' || AppState.user.role === 'ADMIN');
+
+    const addBtn = document.getElementById('add-price-change-btn');
+    if (addBtn) {
+      if (canEdit) {
+        addBtn.style.display = 'flex';
+        addBtn.onclick = () => OrderTypePricesManager.showPriceForm(null, OrderTypePricesManager._current || {});
+      } else {
+        addBtn.style.display = 'none';
+      }
+    }
+
+    try {
+      const [currentResp, historyResp] = await Promise.all([
+        ApiClient.getCurrentOrderTypePrices(),
+        ApiClient.getOrderTypePriceHistory()
+      ]);
+      const current = currentResp.current || {};
+      const history = historyResp.history || [];
+      OrderTypePricesManager._current = current;
+
+      // Cartes des prix courants (un par type)
+      const types = OrderTypePricesManager.allTypes();
+      const cards = types.map(type => {
+        const c = current[type] || {};
+        const isMata = type === 'MATA';
+        return `
+          <div style="background:white;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.08);padding:20px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
+              <h3 style="margin:0;font-size:17px;font-weight:700;color:#2c3e50;">${Utils.escapeHtml(OrderTypePricesManager.labelFor(type))}</h3>
+              <span style="background:#eef2ff;color:#4f46e5;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:600;">${Utils.escapeHtml(type)}</span>
+            </div>
+            <div style="font-size:24px;font-weight:800;color:#2c3e50;">${OrderTypePricesManager.fmtPrice(c.default_price)}</div>
+            ${isMata ? `<div style="font-size:13px;color:#6c757d;margin-top:6px;">Supplément hors-zone : <b>${c.hors_zone_supplement != null ? Number(c.hors_zone_supplement).toLocaleString('fr-FR') + ' FCFA' : '—'}</b></div>` : ''}
+            <div style="font-size:12px;color:#adb5bd;margin-top:8px;">Depuis le ${OrderTypePricesManager.fmtDate(c.effective_from)}</div>
+            ${canEdit ? `<button class="btn btn-sm btn-primary change-price-btn" data-type="${Utils.escapeHtml(type)}" style="margin-top:14px;border-radius:8px;font-size:12px;padding:6px 14px;">Changer</button>` : ''}
+          </div>`;
+      }).join('');
+
+      const nbCols = canEdit ? 7 : 6;
+      const historyRows = history.map(h => `
+        <tr>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;">${Utils.escapeHtml(OrderTypePricesManager.labelFor(h.order_type))}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;">${OrderTypePricesManager.fmtPrice(h.default_price)}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;">${h.hors_zone_supplement != null ? Number(h.hors_zone_supplement).toLocaleString('fr-FR') + ' FCFA' : '—'}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;">${OrderTypePricesManager.fmtDate(h.effective_from)}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;color:#6c757d;">${h.created_by_username ? Utils.escapeHtml(h.created_by_username) : '—'}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;color:#6c757d;">${h.comment ? Utils.escapeHtml(h.comment) : ''}</td>
+          ${canEdit ? `<td style="padding:10px 12px;border-bottom:1px solid #f0f0f0;"><button class="btn btn-sm btn-danger delete-price-btn" data-id="${h.id}" style="border-radius:6px;font-size:11px;padding:4px 10px;">Suppr.</button></td>` : ''}
+        </tr>`).join('');
+
+      container.innerHTML = `
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px;margin-bottom:32px;">
+          ${cards}
+        </div>
+        <h3 style="font-size:16px;font-weight:700;color:#2c3e50;margin:0 0 12px 4px;">Historique des changements</h3>
+        <div style="background:white;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.08);overflow-x:auto;">
+          <table style="width:100%;border-collapse:collapse;font-size:14px;">
+            <thead>
+              <tr style="background:#f8f9fa;text-align:left;">
+                <th style="padding:12px;font-weight:600;color:#495057;">Type</th>
+                <th style="padding:12px;font-weight:600;color:#495057;">Prix par défaut</th>
+                <th style="padding:12px;font-weight:600;color:#495057;">Supplément hors-zone</th>
+                <th style="padding:12px;font-weight:600;color:#495057;">Date d'effet</th>
+                <th style="padding:12px;font-weight:600;color:#495057;">Par</th>
+                <th style="padding:12px;font-weight:600;color:#495057;">Commentaire</th>
+                ${canEdit ? '<th style="padding:12px;"></th>' : ''}
+              </tr>
+            </thead>
+            <tbody>
+              ${historyRows || `<tr><td colspan="${nbCols}" style="padding:20px;text-align:center;color:#6c757d;">Aucun historique.</td></tr>`}
+            </tbody>
+          </table>
+        </div>
+      `;
+
+      if (canEdit) {
+        container.querySelectorAll('.change-price-btn').forEach(btn => {
+          btn.addEventListener('click', () => OrderTypePricesManager.showPriceForm(btn.dataset.type, current));
+        });
+        container.querySelectorAll('.delete-price-btn').forEach(btn => {
+          btn.addEventListener('click', () => OrderTypePricesManager.deleteEntry(btn.dataset.id));
+        });
+      }
+    } catch (err) {
+      console.error('Erreur chargement prix:', err);
+      container.innerHTML = '<p style="color:#dc3545;text-align:center;padding:20px;">Erreur lors du chargement des prix.</p>';
+    }
+  }
+
+  static showPriceForm(presetType, current) {
+    const types = OrderTypePricesManager.allTypes();
+    const cur = current || {};
+    const today = new Date().toISOString().slice(0, 10);
+    const selectedType = presetType || types[0];
+
+    const typeOptions = types.map(t =>
+      `<option value="${Utils.escapeHtml(t)}" ${t === selectedType ? 'selected' : ''}>${Utils.escapeHtml(OrderTypePricesManager.labelFor(t))} (${Utils.escapeHtml(t)})</option>`
+    ).join('');
+
+    ModalManager.show('Changer un prix', `
+      <form id="price-change-form">
+        <div class="form-group">
+          <label>Type de commande *</label>
+          <select id="price-type" required>${typeOptions}</select>
+        </div>
+        <div class="form-group">
+          <label>Prix par défaut (FCFA)</label>
+          <input type="number" id="price-default" min="0" step="1" placeholder="Vide = saisie libre">
+          <small style="color:#6c757d;">Laisser vide pour que le livreur saisisse le prix (ex : MLC piloté par zones).</small>
+        </div>
+        <div class="form-group" id="price-supplement-group">
+          <label>Supplément hors-zone (FCFA)</label>
+          <input type="number" id="price-supplement" min="0" step="1" placeholder="Ex : 1000">
+          <small style="color:#6c757d;">Ajouté au prix de base MATA quand « hors zone » est coché.</small>
+        </div>
+        <div class="form-group">
+          <label>Date d'effet *</label>
+          <input type="date" id="price-effective-from" value="${today}" required>
+          <small style="color:#6c757d;">Les commandes à partir de cette date utilisent le nouveau prix. Les rapports antérieurs ne changent pas.</small>
+        </div>
+        <div class="form-group">
+          <label>Commentaire</label>
+          <input type="text" id="price-comment" placeholder="Ex : baisse tarifaire juillet">
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary">Enregistrer</button>
+          <button type="button" class="btn btn-secondary" onclick="ModalManager.hide()">Annuler</button>
+        </div>
+      </form>
+    `);
+
+    const typeSelect = document.getElementById('price-type');
+    const defaultInput = document.getElementById('price-default');
+    const supplementInput = document.getElementById('price-supplement');
+    const supplementGroup = document.getElementById('price-supplement-group');
+
+    const applyTypeDefaults = (type) => {
+      const c = cur[type] || {};
+      defaultInput.value = (c.default_price != null ? c.default_price : '');
+      supplementInput.value = (c.hors_zone_supplement != null ? c.hors_zone_supplement : '');
+      // Le supplément hors-zone ne concerne que MATA
+      supplementGroup.style.display = (type === 'MATA') ? 'block' : 'none';
+    };
+    applyTypeDefaults(selectedType);
+    typeSelect.addEventListener('change', () => applyTypeDefaults(typeSelect.value));
+
+    document.getElementById('price-change-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const type = typeSelect.value;
+      const data = {
+        order_type: type,
+        default_price: defaultInput.value === '' ? null : parseInt(defaultInput.value),
+        hors_zone_supplement: (type === 'MATA' && supplementInput.value !== '') ? parseInt(supplementInput.value) : null,
+        effective_from: document.getElementById('price-effective-from').value,
+        comment: document.getElementById('price-comment').value.trim() || null
+      };
+      try {
+        await ApiClient.createOrderTypePrice(data);
+        ToastManager.success('Prix enregistré');
+        ModalManager.hide();
+        await OrderTypePricesManager.loadPrices();
+        await loadOrderTypePricesConfig(); // recharge les prix courants pour les formulaires de commande
+      } catch (err) {
+        ToastManager.error(err.message || 'Erreur lors de l\'enregistrement');
+      }
+    });
+  }
+
+  static async deleteEntry(id) {
+    ModalManager.confirm(
+      'Supprimer cette entrée',
+      'Supprimer cette entrée d\'historique ? Si elle était déjà appliquée, les rapports concernés seront recalculés.',
+      async () => {
+        try {
+          await ApiClient.deleteOrderTypePrice(id);
+          ToastManager.success('Entrée supprimée');
+          await OrderTypePricesManager.loadPrices();
+          await loadOrderTypePricesConfig();
+        } catch (err) {
+          ToastManager.error(err.message || 'Erreur lors de la suppression');
+        }
+      }
+    );
+  }
+}
+
 // ===== GESTIONNAIRE DE PROFIL =====
 class ProfileManager {
   static async loadProfile() {
@@ -7202,8 +7492,12 @@ class App {
         subscriptionSelectGroup.style.display = 'none'; const _wa = document.getElementById('whatsapp-subscription-btn'); if (_wa) _wa.style.display = 'none';
         mataHorsZoneGroup.style.display = 'block';
         document.getElementById('interne-toggle-group').style.display = 'block';
-        coursePriceInput.value = '1000';
+        const mataDefault = getDefaultCoursePrice('MATA');
+        coursePriceInput.value = (mataDefault != null ? mataDefault : 1000);
         coursePriceInput.readOnly = true;
+        // Libellé du supplément hors-zone selon la config
+        const horsZoneLabelEl = document.querySelector('label[for="mata-hors-zone"]');
+        if (horsZoneLabelEl) horsZoneLabelEl.textContent = `Hors zone (+${getMataHorsZoneSupplement()} FCFA)`;
         
         // Afficher le groupe du bouton historique pour MATA
         const historyButtonGroup = document.getElementById('client-history-button-group');
@@ -7230,9 +7524,10 @@ class App {
         amountGroup.style.display = 'none';
         subscriptionToggleGroup.style.display = 'none';
         subscriptionSelectGroup.style.display = 'none'; const _wa = document.getElementById('whatsapp-subscription-btn'); if (_wa) _wa.style.display = 'none';
-        coursePriceInput.value = '';
+        const typeDefault = getDefaultCoursePrice(orderType);
+        coursePriceInput.value = (typeDefault != null ? typeDefault : '');
         coursePriceInput.readOnly = false;
-        
+
         // Masquer le bouton historique pour les types non-MATA
         const historyButtonGroup = document.getElementById('client-history-button-group');
         if (historyButtonGroup) {
@@ -7257,7 +7552,8 @@ class App {
         supplementToggleGroup.style.display = 'block';
         mlcZoneGroup.style.display = 'none';
         document.getElementById('zone-info').style.display = 'none';
-        coursePriceInput.value = '1000';
+        const mlcDefault = getDefaultCoursePrice('MLC');
+        coursePriceInput.value = (mlcDefault != null ? mlcDefault : 1000);
         coursePriceInput.readOnly = true;
         
         // Charger les abonnements actifs
@@ -7320,12 +7616,13 @@ class App {
       const isHorsZone = e.target.checked;
       const coursePriceInput = document.getElementById('course-price');
       
+      const mataBaseVal = (getDefaultCoursePrice('MATA') != null ? getDefaultCoursePrice('MATA') : 1000);
       if (isHorsZone) {
-        // Ajouter 1000 FCFA au prix par défaut de 1000
-        coursePriceInput.value = '2000';
+        // Ajouter le supplément hors-zone au prix de base MATA
+        coursePriceInput.value = mataBaseVal + getMataHorsZoneSupplement();
       } else {
-        // Remettre le prix par défaut de MATA
-        coursePriceInput.value = '1000';
+        // Remettre le prix de base MATA
+        coursePriceInput.value = mataBaseVal;
       }
     });
 
@@ -8234,6 +8531,7 @@ class App {
 document.addEventListener('DOMContentLoaded', async () => {
   await loadOrderTypesConfig();
   await loadPointsDeVenteConfig();
+  await loadOrderTypePricesConfig();
   populatePointsDeVenteSelects();
   App.init();
   


### PR DESCRIPTION
Add a Manager/Admin admin page to set the default course price per order type, with date-effective historisation so past monthly reports keep the price that applied at the time.

- New order_type_prices table, created + seeded in startup migrations (current values effective 2000-01-01 so existing orders keep MATA base 1000). created_by is UUID to match users.id.
- New /api/v1/order-type-prices routes: current (public, for form prefill), history + POST/DELETE (Manager/Admin, append-only history).
- Monthly recap (Order.getDailyTypeStatsByMonth) derives the MATA hors-zone base from the price effective at each order's date via a LATERAL join, instead of a hardcoded 1000.
- Frontend loads current prices at startup and uses them for the course price defaults (MATA base, hors-zone supplement, per-type prefill), removing hardcoded 1000s in the order form, edit form and "prendre la livraison" flow.
- New "Prix des commandes" admin page (OrderTypePricesManager): current prices per type + full change history + record a change. Restricted to Manager/Admin.