### PR TITLE
feat: chef livreur (réassignation) + vue tableau commandes en cours

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -219,6 +219,14 @@ async function runStartupMigrations() {
     console.error('⚠️ Migration allowed_order_types:', err.message);
   }
 
+  // Flag "chef livreur" (livreur pouvant voir et réassigner toutes les commandes en cours)
+  try {
+    await db.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS is_chef_livreur BOOLEAN NOT NULL DEFAULT false`);
+    console.log('✅ Migration: is_chef_livreur OK');
+  } catch (err) {
+    console.error('⚠️ Migration is_chef_livreur:', err.message);
+  }
+
   // Table mlc_zones
   try {
     await db.query(`

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -64,7 +64,8 @@ class AuthController {
           id: user.id,
           username: user.username,
           role: user.role,
-          allowed_order_types: user.allowed_order_types || null
+          allowed_order_types: user.allowed_order_types || null,
+          is_chef_livreur: user.is_chef_livreur === true
         },
         token: token // Include token for mobile fallback
       });
@@ -112,7 +113,8 @@ class AuthController {
           id: req.user.id,
           username: req.user.username,
           role: req.user.role,
-          allowed_order_types: req.user.allowed_order_types || null
+          allowed_order_types: req.user.allowed_order_types || null,
+          is_chef_livreur: req.user.is_chef_livreur === true
         }
       });
 

--- a/backend/controllers/commandeEnCoursController.js
+++ b/backend/controllers/commandeEnCoursController.js
@@ -254,8 +254,9 @@ const getCommandesEnCours = async (req, res) => {
     const params = [];
     let paramCounter = 1;
 
-    // Si l'utilisateur est un livreur, filtrer automatiquement par son ID
-    if (user && user.role === 'LIVREUR') {
+    // Si l'utilisateur est un livreur (mais PAS un chef livreur), filtrer sur ses propres commandes.
+    // Un chef livreur voit toutes les commandes en cours (comme un manager) pour pouvoir les réassigner.
+    if (user && user.role === 'LIVREUR' && !user.is_chef_livreur) {
       // Pour les livreurs, on filtre par leur username (qui est stocké dans livreur_id)
       query += ` AND livreur_id = $${paramCounter}`;
       params.push(user.username); // Utiliser username (plus simple)
@@ -385,8 +386,8 @@ const updateStatutCommande = async (req, res) => {
       });
     }
 
-    // Vérifier si l'utilisateur est un livreur
-    if (user.role === 'LIVREUR') {
+    // Vérifier si l'utilisateur est un livreur (un chef livreur peut agir sur toutes les commandes)
+    if (user.role === 'LIVREUR' && !user.is_chef_livreur) {
       // Vérifier que la commande appartient au livreur
       const checkQuery = `
         SELECT livreur_id FROM commandes_en_cours WHERE id = $1
@@ -450,13 +451,13 @@ const reassignCommande = async (req, res) => {
   try {
     const { id } = req.params;
     const { nouveau_livreur_id } = req.body;
-    const { role } = req.user;
+    const { role, is_chef_livreur } = req.user;
 
-    // Vérifier que l'utilisateur est MANAGER ou ADMIN
-    if (role !== 'MANAGER' && role !== 'ADMIN') {
+    // Autorisé pour MANAGER/ADMIN et pour les chefs livreurs (livreurs avec le flag is_chef_livreur)
+    if (role !== 'MANAGER' && role !== 'ADMIN' && !(role === 'LIVREUR' && is_chef_livreur)) {
       return res.status(403).json({
         success: false,
-        error: 'Seuls les managers et admins peuvent réassigner des commandes'
+        error: 'Seuls les managers, admins et chefs livreurs peuvent réassigner des commandes'
       });
     }
 

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -77,7 +77,7 @@ class UserController {
   // Créer un nouvel utilisateur
   static async createUser(req, res) {
     try {
-      const { username, password, role } = req.body;
+      const { username, password, role, is_chef_livreur } = req.body;
 
       // Vérifier que l'utilisateur actuel a les permissions
       if (req.user.role === 'MANAGER' && role === 'ADMIN') {
@@ -89,7 +89,8 @@ class UserController {
       const newUser = await User.create({
         username,
         password,
-        role
+        role,
+        is_chef_livreur: role === 'LIVREUR' ? (is_chef_livreur === true || is_chef_livreur === 'true') : false
       });
 
       res.status(201).json({
@@ -157,6 +158,12 @@ class UserController {
         } else if (!Array.isArray(updates.allowed_order_types)) {
           return res.status(400).json({ error: 'allowed_order_types doit être un tableau' });
         }
+      }
+
+      // Normaliser is_chef_livreur : booléen, et forcé à false si le rôle (effectif) n'est pas LIVREUR
+      if (updates.is_chef_livreur !== undefined) {
+        const effectiveRole = updates.role || existingUser.role;
+        updates.is_chef_livreur = (effectiveRole === 'LIVREUR') ? (updates.is_chef_livreur === true || updates.is_chef_livreur === 'true') : false;
       }
 
       const updatedUser = await User.update(id, updates);

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -113,7 +113,12 @@ const validateUserCreation = [
   body('role')
     .isIn(['LIVREUR', 'MANAGER', 'ADMIN', 'READONLY'])
     .withMessage('Le rôle doit être LIVREUR, MANAGER, ADMIN ou READONLY'),
-    
+
+  body('is_chef_livreur')
+    .optional()
+    .isBoolean()
+    .withMessage('is_chef_livreur doit être un booléen'),
+
   handleValidationErrors
 ];
 
@@ -131,7 +136,12 @@ const validateUserUpdate = [
     .optional()
     .isIn(['LIVREUR', 'MANAGER', 'ADMIN', 'READONLY'])
     .withMessage('Le rôle doit être LIVREUR, MANAGER, ADMIN ou READONLY'),
-    
+
+  body('is_chef_livreur')
+    .optional()
+    .isBoolean()
+    .withMessage('is_chef_livreur doit être un booléen'),
+
   handleValidationErrors
 ];
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -12,21 +12,23 @@ class User {
     this.created_at = data.created_at;
     this.updated_at = data.updated_at;
     this.allowed_order_types = data.allowed_order_types || null;
+    this.is_chef_livreur = data.is_chef_livreur === true;
   }
 
   // Créer un nouvel utilisateur
-  static async create({ username, password, role, is_active = true }) {
+  static async create({ username, password, role, is_active = true, is_chef_livreur = false }) {
     const id = uuidv4();
     const password_hash = await bcrypt.hash(password, 12);
-    
+
     const query = `
-      INSERT INTO users (id, username, password_hash, role, is_active)
-      VALUES ($1, $2, $3, $4, $5)
+      INSERT INTO users (id, username, password_hash, role, is_active, is_chef_livreur)
+      VALUES ($1, $2, $3, $4, $5, $6)
       RETURNING *
     `;
-    
+
     try {
-      const result = await db.query(query, [id, username, password_hash, role, is_active]);
+      // Le flag "chef livreur" n'a de sens que pour un LIVREUR
+      const result = await db.query(query, [id, username, password_hash, role, is_active, role === 'LIVREUR' ? (is_chef_livreur === true || is_chef_livreur === 'true') : false]);
       return new User(result.rows[0]);
     } catch (error) {
       if (error.code === '23505') { // Violation de contrainte unique
@@ -94,7 +96,7 @@ class User {
 
   // Mettre à jour un utilisateur
   static async update(id, updates) {
-    const allowedFields = ['username', 'role', 'is_active', 'allowed_order_types'];
+    const allowedFields = ['username', 'role', 'is_active', 'allowed_order_types', 'is_chef_livreur'];
     const setClause = [];
     const values = [];
     let paramIndex = 1;
@@ -210,6 +212,11 @@ class User {
       result: this.role === 'MANAGER' || this.role === 'ADMIN'
     });
     return this.role === 'MANAGER' || this.role === 'ADMIN';
+  }
+
+  // Vérifier si l'utilisateur est un chef livreur (livreur avec droits de réassignation)
+  isChefLivreur() {
+    return this.role === 'LIVREUR' && this.is_chef_livreur === true;
   }
 
   // Vérifier si l'utilisateur est admin

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -17,6 +17,17 @@ const {
   sanitizeInput
 } = require('../middleware/validation');
 
+// Autorise MANAGER/ADMIN/READONLY et les chefs livreurs (LIVREUR + is_chef_livreur).
+// Utilisé uniquement pour la liste des livreurs actifs (modale de réassignation),
+// sans élargir l'accès à la liste complète des utilisateurs.
+const requireViewerOrChefLivreur = (req, res, next) => {
+  const u = req.user;
+  if (u && (['MANAGER', 'ADMIN', 'READONLY'].includes(u.role) || (u.role === 'LIVREUR' && u.is_chef_livreur === true))) {
+    return next();
+  }
+  return res.status(403).json({ error: 'Permissions insuffisantes' });
+};
+
 // Toutes les routes nécessitent une authentification
 router.use(authenticateToken);
 
@@ -25,7 +36,7 @@ router.get('/', requireViewer, UserController.getAllUsers);
 router.get('/stats', requireViewer, UserController.getUserStats);
 router.get('/role/:role', requireViewer, UserController.getUsersByRole);
 router.get('/livreurs', requireViewer, UserController.getAllLivreurs);
-router.get('/livreurs/active', requireViewer, UserController.getActiveLivreurs);
+router.get('/livreurs/active', requireViewerOrChefLivreur, UserController.getActiveLivreurs);
 router.get('/active', requireViewer, UserController.getAllActiveUsers);
 router.get('/:id', requireViewer, validateUUID, UserController.getUserById);
 

--- a/frontend/js/commandes-en-cours.js
+++ b/frontend/js/commandes-en-cours.js
@@ -13,6 +13,10 @@ let currentFilters = {
 };
 let autoRefreshInterval = null; // Pour éviter les multiples intervalles
 let isLoadingCommandes = false; // Pour éviter les appels simultanés
+// Vue d'affichage: 'cards' | 'table' | null. null = aucune préférence explicite -> défaut selon le rôle.
+let currentView = (() => { try { return localStorage.getItem('cec_view'); } catch (e) { return null; } })();
+// Vue effective : tableau par défaut pour chef livreur / manager / admin ; cartes pour un livreur simple.
+function effectiveView() { return currentView || (canToggleView() ? 'table' : 'cards'); }
 
 /**
  * Récupérer le rôle de l'utilisateur courant
@@ -20,6 +24,33 @@ let isLoadingCommandes = false; // Pour éviter les appels simultanés
 function getUserRole() {
   const roleElement = document.getElementById('user-role');
   return roleElement ? roleElement.textContent.trim() : null;
+}
+
+/**
+ * Le chef livreur est un LIVREUR avec le flag is_chef_livreur (exposé via AppState.user).
+ */
+function isChefLivreur() {
+  return !!(window.AppState && window.AppState.user && window.AppState.user.is_chef_livreur);
+}
+
+/**
+ * Qui peut basculer entre vue Cartes et vue Tableau : manager, admin et chef livreur.
+ */
+function canToggleView() {
+  const role = getUserRole();
+  return role === 'MANAGER' || role === 'ADMIN' || isChefLivreur();
+}
+
+function setCommandesView(view) {
+  currentView = view;
+  try { localStorage.setItem('cec_view', view); } catch (e) {}
+  displayCommandesEnCours();
+}
+
+function attachViewToggleListeners() {
+  document.querySelectorAll('.cec-view-btn').forEach(btn => {
+    btn.addEventListener('click', () => setCommandesView(btn.dataset.view));
+  });
 }
 
 /**
@@ -147,7 +178,25 @@ function displayCommandesEnCours() {
     `;
     return;
   }
-  
+
+  // Barre de bascule Cartes / Tableau (chef livreur, manager, admin)
+  const showToggle = canToggleView();
+  const view = effectiveView();
+  const toggleBar = showToggle ? `
+    <div class="cec-view-toggle" style="display:flex; gap:8px; margin-bottom:1rem;">
+      <button type="button" class="btn btn-sm cec-view-btn ${view === 'cards' ? 'btn-primary' : 'btn-secondary'}" data-view="cards">🗂️ Cartes</button>
+      <button type="button" class="btn btn-sm cec-view-btn ${view === 'table' ? 'btn-primary' : 'btn-secondary'}" data-view="table">📋 Tableau</button>
+    </div>
+  ` : '';
+
+  // Vue tableau (réservée à ceux qui ont le toggle)
+  if (showToggle && view === 'table') {
+    container.innerHTML = toggleBar + renderCommandesTable(commandesEnCoursData);
+    attachViewToggleListeners();
+    addCommandeActionListeners();
+    return;
+  }
+
   // Grouper les commandes par statut
   const grouped = {
     en_livraison: [],
@@ -161,8 +210,8 @@ function displayCommandesEnCours() {
     }
   });
   
-  let html = '';
-  
+  let html = toggleBar;
+
   // Afficher les commandes en livraison
   if (grouped.en_livraison.length > 0) {
     html += `
@@ -200,8 +249,9 @@ function displayCommandesEnCours() {
   }
   
   container.innerHTML = html;
-  
-  // Ajouter les event listeners pour les boutons d'action
+
+  // Réactiver la bascule de vue + les actions
+  attachViewToggleListeners();
   addCommandeActionListeners();
 }
 
@@ -304,27 +354,82 @@ function renderCommandeCard(commande) {
       </div>
       
       <div class="commande-actions">
-        ${commande.statut === 'en_livraison' ? `
-          ${getUserRole() === 'LIVREUR' ? `
-            <button class="btn btn-primary btn-sm prendre-livraison" data-id="${commande.id}">
-              <span class="icon">📦</span> Prendre la livraison
-            </button>
-          ` : `
-            <button class="btn btn-warning btn-sm reassign-livreur" data-id="${commande.id}">
-              <span class="icon">🔄</span> Réassigner livreur
-            </button>
-          `}
-          <button class="btn btn-danger btn-sm mark-annulee" data-id="${commande.id}">
-            <span class="icon">❌</span> Annuler
-          </button>
-        ` : ''}
-        ${getUserRole() === 'MANAGER' || getUserRole() === 'ADMIN' ? `
-          <button class="btn btn-secondary btn-sm delete-commande" data-id="${commande.id}">
-            <span class="icon">🗑️</span> Supprimer
-          </button>
-        ` : ''}
+        ${renderCommandeActionButtons(commande)}
       </div>
     </div>
+  `;
+}
+
+/**
+ * Boutons d'action d'une commande, partagés entre la vue Cartes et la vue Tableau.
+ * - LIVREUR simple : Prendre la livraison
+ * - Chef livreur   : Prendre la livraison + Réassigner
+ * - MANAGER/ADMIN  : Réassigner (+ Supprimer)
+ * (Annuler visible par tous pour une commande en livraison — comportement existant conservé.)
+ */
+function renderCommandeActionButtons(commande) {
+  const role = getUserRole();
+  const chef = isChefLivreur();
+  let html = '';
+  if (commande.statut === 'en_livraison') {
+    if (role === 'LIVREUR') {
+      html += `<button class="btn btn-primary btn-sm prendre-livraison" data-id="${commande.id}"><span class="icon">📦</span> Prendre la livraison</button>`;
+    }
+    if (role !== 'LIVREUR' || chef) {
+      html += `<button class="btn btn-warning btn-sm reassign-livreur" data-id="${commande.id}"><span class="icon">🔄</span> Réassigner livreur</button>`;
+    }
+    html += `<button class="btn btn-danger btn-sm mark-annulee" data-id="${commande.id}"><span class="icon">❌</span> Annuler</button>`;
+  }
+  if (role === 'MANAGER' || role === 'ADMIN') {
+    html += `<button class="btn btn-secondary btn-sm delete-commande" data-id="${commande.id}"><span class="icon">🗑️</span> Supprimer</button>`;
+  }
+  return html;
+}
+
+/**
+ * Vue tableau des commandes en cours (colonnes enrichies). Réutilise les mêmes boutons
+ * d'action (mêmes classes/data-id) que les cartes, donc addCommandeActionListeners suffit.
+ */
+function renderCommandesTable(list) {
+  const statutLabels = { en_livraison: '🚚 En livraison', livree: '✅ Livrée', annulee: '❌ Annulée' };
+  const order = { en_livraison: 0, livree: 1, annulee: 2 };
+  const rows = [...list].sort((a, b) => (order[a.statut] ?? 9) - (order[b.statut] ?? 9));
+  return `
+    <div class="table-responsive" style="overflow-x:auto;">
+      <table class="commandes-table" style="width:100%; border-collapse:collapse;">
+        <thead>
+          <tr style="background:#2563eb; color:#fff; text-align:left;">
+            <th style="padding:10px;">Client</th>
+            <th style="padding:10px;">Téléphone</th>
+            <th style="padding:10px;">Adresse</th>
+            <th style="padding:10px;">Point de vente</th>
+            <th style="padding:10px;">Livreur</th>
+            <th style="padding:10px; text-align:right;">Total</th>
+            <th style="padding:10px;">Statut</th>
+            <th style="padding:10px;">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.map(cmd => renderCommandeRow(cmd, statutLabels)).join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderCommandeRow(commande, statutLabels) {
+  const total = Number(commande.total || 0).toLocaleString();
+  return `
+    <tr data-id="${commande.id}" data-statut="${commande.statut}" style="border-bottom:1px solid #e5e7eb;">
+      <td style="padding:10px;"><strong>${commande.client_nom || ''}</strong></td>
+      <td style="padding:10px;">${commande.client_telephone || ''}</td>
+      <td style="padding:10px;">${commande.client_adresse || ''}</td>
+      <td style="padding:10px;">${commande.point_vente || ''}</td>
+      <td style="padding:10px;">${commande.livreur_nom || ''}</td>
+      <td style="padding:10px; text-align:right; white-space:nowrap;">${total} FCFA</td>
+      <td style="padding:10px; white-space:nowrap;">${statutLabels[commande.statut] || commande.statut}</td>
+      <td style="padding:10px;"><div class="commande-actions" style="display:flex; gap:6px; flex-wrap:wrap;">${renderCommandeActionButtons(commande)}</div></td>
+    </tr>
   `;
 }
 
@@ -532,9 +637,10 @@ async function prendreLivraison(id) {
  */
 async function showReassignModal(id) {
   try {
-    // Récupérer la liste des livreurs actifs
-    const response = await ApiClient.request('/users?role=LIVREUR&active=true');
-    const livreurs = response.data || [];
+    // Récupérer la liste des livreurs actifs (endpoint dédié, accessible aux chefs livreurs).
+    // Corrige aussi un bug préexistant : l'ancien appel lisait response.data qui n'existe pas.
+    const response = await ApiClient.getActiveLivreurs();
+    const livreurs = response.livreurs || [];
 
     if (livreurs.length === 0) {
       if (window.ToastManager) {
@@ -544,7 +650,8 @@ async function showReassignModal(id) {
     }
 
     // Trouver la commande
-    const commande = commandesEnCoursData.find(c => c.id === id);
+    // c.id est un nombre, id vient de data-id (chaîne) -> comparaison souple (comme ligne ~529)
+    const commande = commandesEnCoursData.find(c => c.id == id);
 
     // Créer le contenu de la modal
     const modalContent = `

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -5335,7 +5335,14 @@ class UserManager {
             ${AppState.user.role === 'ADMIN' ? '<option value="ADMIN">ADMIN</option>' : ''}
           </select>
         </div>
-        
+
+        <div class="form-group" id="create-chef-livreur-group" style="display:none;">
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+            <input type="checkbox" id="create-is-chef-livreur" name="is_chef_livreur">
+            Chef livreur (peut voir et réassigner toutes les commandes en cours)
+          </label>
+        </div>
+
         <div class="form-actions">
           <button type="submit" class="btn btn-primary">Créer</button>
           <button type="button" class="btn btn-secondary modal-cancel-btn">Annuler</button>
@@ -5350,11 +5357,24 @@ class UserManager {
       ModalManager.hide();
     });
 
+    // Afficher la case "Chef livreur" uniquement pour le rôle LIVREUR
+    const createRoleSel = document.getElementById('create-role');
+    const createChefGroup = document.getElementById('create-chef-livreur-group');
+    const createChefBox = document.getElementById('create-is-chef-livreur');
+    const toggleCreateChef = () => {
+      const isLiv = createRoleSel.value === 'LIVREUR';
+      createChefGroup.style.display = isLiv ? 'block' : 'none';
+      if (!isLiv) createChefBox.checked = false;
+    };
+    createRoleSel.addEventListener('change', toggleCreateChef);
+    toggleCreateChef();
+
     document.getElementById('create-user-form').addEventListener('submit', async (e) => {
       e.preventDefault();
       
       const formData = new FormData(e.target);
       const userData = Object.fromEntries(formData.entries());
+      userData.is_chef_livreur = document.getElementById('create-is-chef-livreur').checked;
 
       try {
         await ApiClient.createUser(userData);
@@ -5391,7 +5411,14 @@ class UserManager {
               ${AppState.user.role === 'ADMIN' ? `<option value="ADMIN" ${user.role === 'ADMIN' ? 'selected' : ''}>ADMIN</option>` : ''}
             </select>
           </div>
-          
+
+          <div class="form-group" id="edit-chef-livreur-group" style="display:${user.role === 'LIVREUR' ? 'block' : 'none'};">
+            <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+              <input type="checkbox" id="edit-is-chef-livreur" name="is_chef_livreur" ${user.is_chef_livreur ? 'checked' : ''}>
+              Chef livreur (peut voir et réassigner toutes les commandes en cours)
+            </label>
+          </div>
+
           <div class="form-actions">
             <button type="submit" class="btn btn-primary">Sauvegarder</button>
             <button type="button" class="btn btn-secondary modal-cancel-btn">Annuler</button>
@@ -5429,6 +5456,18 @@ class UserManager {
       document.querySelector('.modal-cancel-btn').addEventListener('click', () => {
         ModalManager.hide();
       });
+
+      // Afficher la case "Chef livreur" uniquement pour le rôle LIVREUR
+      const editRoleSel = document.getElementById('edit-role');
+      const editChefGroup = document.getElementById('edit-chef-livreur-group');
+      const editChefBox = document.getElementById('edit-is-chef-livreur');
+      const toggleEditChef = () => {
+        const isLiv = editRoleSel.value === 'LIVREUR';
+        editChefGroup.style.display = isLiv ? 'block' : 'none';
+        if (!isLiv) editChefBox.checked = false;
+      };
+      editRoleSel.addEventListener('change', toggleEditChef);
+      toggleEditChef();
 
       // Toggle affichage du formulaire de reset
       document.getElementById('show-reset-password-btn').addEventListener('click', () => {
@@ -5473,6 +5512,7 @@ class UserManager {
 
         const formData = new FormData(e.target);
         const userData = Object.fromEntries(formData.entries());
+        userData.is_chef_livreur = document.getElementById('edit-is-chef-livreur').checked;
 
         try {
           await ApiClient.updateUser(userId, userData);


### PR DESCRIPTION
## Résumé
Ajoute la notion de **chef livreur** et une **vue tableau** sur « Commandes en cours ».

- **Chef livreur** : un LIVREUR avec une case à cocher `is_chef_livreur` (page Utilisateurs, visible seulement pour le rôle LIVREUR). Il voit **toutes** les commandes en cours (comme un manager), peut les **réassigner** à d'autres livreurs de façon **illimitée**, peut **annuler** n'importe quelle commande, et garde **Prendre la livraison**.
- **Vue tableau** : bascule Cartes/Tableau sur la page, colonnes enrichies (client, téléphone, adresse, point de vente, livreur, total, statut, actions). **Tableau par défaut** pour chef livreur / manager / admin ; cartes pour un livreur simple. Choix mémorisé (localStorage).

## Backend
- Migration `users.is_chef_livreur BOOLEAN NOT NULL DEFAULT false` au démarrage.
- Flag threadé du modèle jusqu'au payload d'auth (`/auth/login`, `/auth/check`).
- `reassignCommande` et `updateStatutCommande` autorisés au chef ; `getCommandesEnCours` sans filtre "propres commandes" pour le chef.
- `GET /users/livreurs/active` ouvert au chef via un garde étroit (sans élargir la liste complète des utilisateurs).
- Coercition booléenne stricte du flag (create/update, modèle + contrôleur).

## Frontend
- Case « Chef livreur » (création + édition), affichée dynamiquement selon le rôle.
- Bascule + rendu tableau, boutons d'action partagés cartes/tableau.
- Correctifs de la modale de réassignation : liste de livreurs vide (`response.livreurs`) et comparaison d'id nombre/chaîne.

## Tests
Vérifié de bout en bout (API avec tokens + Puppeteer) : permissions chef vs livreur simple vs manager/admin, réassignation multiple, visibilité, annulation, coercition `"false"`, case à cocher, vue par défaut par rôle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new “Chef livreur” user flag.
  * Users with this flag can access broader delivery-order actions and a new table view for in-progress orders.
  * User creation and editing screens now let admins set this flag for delivery roles.

* **Bug Fixes**
  * Improved order visibility, reassignment, and status updates for chef livreur accounts.
  * Active delivery-livreur access and authentication responses now include the new flag consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->