### PR TITLE
fix: réassignation invisible + bouton Voir détail (commandes en cours)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -277,6 +277,21 @@ async function runStartupMigrations() {
   } catch (err) {
     console.error('⚠️ Migration idx_orders_type_created_at:', err.message);
   }
+
+  // Normaliser les commandes en cours dont livreur_id est un UUID au lieu du username.
+  // Une ancienne réassignation stockait l'UUID -> la commande devenait invisible dans le
+  // dashboard du nouveau livreur (filtré par livreur_id = username). Idempotent.
+  try {
+    const r = await db.query(`
+      UPDATE commandes_en_cours c
+      SET livreur_id = u.username
+      FROM users u
+      WHERE c.livreur_id = u.id::text AND c.livreur_id <> u.username
+    `);
+    console.log(`✅ Migration: normalisation livreur_id commandes_en_cours OK (${r.rowCount} ligne(s))`);
+  } catch (err) {
+    console.error('⚠️ Migration normalisation livreur_id:', err.message);
+  }
 }
 
 // Démarrage du serveur

--- a/backend/controllers/commandeEnCoursController.js
+++ b/backend/controllers/commandeEnCoursController.js
@@ -502,7 +502,11 @@ const reassignCommande = async (req, res) => {
       RETURNING *
     `;
 
-    const result = await db.query(updateQuery, [livreur.id, livreur.username, id]);
+    // IMPORTANT: livreur_id stocke le USERNAME (pas l'UUID), comme à la création
+    // (createCommandeEnCours) et comme attendu par le filtre de getCommandesEnCours
+    // (livreur_id = user.username). Utiliser l'UUID ici rendait la commande invisible
+    // dans le dashboard du nouveau livreur.
+    const result = await db.query(updateQuery, [livreur.username, livreur.username, id]);
 
     if (result.rows.length === 0) {
       return res.status(404).json({

--- a/frontend/js/commandes-en-cours.js
+++ b/frontend/js/commandes-en-cours.js
@@ -370,7 +370,8 @@ function renderCommandeCard(commande) {
 function renderCommandeActionButtons(commande) {
   const role = getUserRole();
   const chef = isChefLivreur();
-  let html = '';
+  // Bouton "Voir" (détail) disponible pour tous, quel que soit le statut.
+  let html = `<button class="btn btn-info btn-sm view-commande" data-id="${commande.id}"><span class="icon">👁️</span> Voir</button>`;
   if (commande.statut === 'en_livraison') {
     if (role === 'LIVREUR') {
       html += `<button class="btn btn-primary btn-sm prendre-livraison" data-id="${commande.id}"><span class="icon">📦</span> Prendre la livraison</button>`;
@@ -431,6 +432,44 @@ function renderCommandeRow(commande, statutLabels) {
       <td style="padding:10px;"><div class="commande-actions" style="display:flex; gap:6px; flex-wrap:wrap;">${renderCommandeActionButtons(commande)}</div></td>
     </tr>
   `;
+}
+
+/**
+ * Afficher le détail complet d'une commande dans une modale (bouton "Voir").
+ */
+function showCommandeDetail(id) {
+  var commande = commandesEnCoursData.find(c => c.id == id);
+  if (!commande) {
+    if (window.ToastManager) ToastManager.error('Commande introuvable');
+    return;
+  }
+  var statutLabels = { en_livraison: '🚚 En livraison', livree: '✅ Livrée', annulee: '❌ Annulée' };
+  var dd = new Date(commande.date_commande);
+  var dateStr = isNaN(dd.getTime()) ? (commande.date_commande || '') : dd.toLocaleString('fr-FR');
+  var articles = Array.isArray(commande.articles) ? commande.articles : [];
+  var nbArticles = articles.reduce((s, a) => s + (a.quantite || 0), 0);
+  var row = (label, value) => `<div style="display:flex; justify-content:space-between; gap:16px; padding:6px 0; border-bottom:1px solid #f0f0f0;"><span style="color:#666;">${label}</span><span style="font-weight:600; text-align:right;">${(value===0||value)?value:'—'}</span></div>`;
+  var content = `
+    <div class="commande-detail">
+      ${row('📦 Commande', commande.commande_id)}
+      ${row('Statut', statutLabels[commande.statut] || commande.statut)}
+      ${row('🚚 Livreur', commande.livreur_nom)}
+      ${row('👤 Client', commande.client_nom)}
+      ${row('📞 Téléphone', commande.client_telephone)}
+      ${row('📍 Adresse', commande.client_adresse)}
+      ${row('🏪 Point de vente', commande.point_vente)}
+      ${row('🏭 Point de vente exécutant', commande.point_vente_executant)}
+      ${row('📅 Date', dateStr)}
+      <div style="margin-top:12px;"><strong>📦 Articles (${nbArticles})</strong></div>
+      <ul style="list-style:none; padding:0; margin:8px 0;">
+        ${articles.map(a => `<li style="display:flex; justify-content:space-between; gap:12px; padding:4px 0; border-bottom:1px dashed #eee;"><span>${a.produit || ''}</span><span>x${a.quantite || 0}</span><span style="font-weight:600;">${Number(a.prix || 0).toLocaleString()} FCFA</span></li>`).join('') || '<li style="color:#999;">Aucun article</li>'}
+      </ul>
+      <div style="display:flex; justify-content:space-between; padding-top:10px; border-top:2px solid #2563eb; font-size:1.1em;"><strong>Total</strong><strong>${Number(commande.total || 0).toLocaleString()} FCFA</strong></div>
+    </div>
+  `;
+  if (window.ModalManager) {
+    window.ModalManager.show('Détail de la commande', content);
+  }
 }
 
 /**
@@ -514,6 +553,13 @@ function addCommandeActionListeners() {
           await deleteCommande(id);
         }
       }
+    });
+  });
+
+  // Voir le détail (bouton view)
+  document.querySelectorAll('.view-commande').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      showCommandeDetail(e.currentTarget.dataset.id);
     });
   });
 }


### PR DESCRIPTION
## Contexte
Bug remonté en prod : un chef livreur réassigne une course à un livreur, mais **le livreur ne la voit pas dans son dashboard**.

## Cause racine
`reassignCommande` stockait `livreur_id = <UUID du livreur>`, alors que la création (`createCommandeEnCours`) et le filtre du dashboard (`getCommandesEnCours` → `livreur_id = username`) utilisent le **username**. La commande réassignée devenait donc invisible pour le nouveau livreur.

## Correctifs
- **Code** : la réassignation stocke désormais `livreur.username` dans `livreur_id`.
- **Migration de récupération** (au démarrage, idempotente) : normalise les `livreur_id` déjà stockés en UUID → username, pour récupérer les commandes « bloquées » existantes en prod.

## Bonus (même page)
- Bouton **« Voir »** (œil) dans la colonne Actions (vue tableau et cartes) → modale de détail complet de la commande (client, téléphone, adresse, points de vente, date, articles, total).

## Tests (local, mlc_db)
- Reproduction : réassignation → `livreur_id` = UUID → le livreur voit **0** commande.
- Après fix : réassignation → `livreur_id` = username → le nouveau livreur **voit** la commande. Migration : **7 lignes** récupérées, 0 restante en UUID. Bouton Voir vérifié via Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **View** action for orders, letting users open a detailed modal with order status, customer info, delivery details, items, and total.
* **Bug Fixes**
  * Improved order reassignment so delivery assignments stay consistent and continue to appear correctly in the live order view.
  * Added a startup data correction to keep existing order records aligned with the current delivery-user format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->