### PR TITLE
feat: points de vente éditables via l'UI + masquage de 3 menus

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -32,6 +32,7 @@ const versementsRoutes = require('./routes/versements');
 const mlcZonesRoutes = require('./routes/mlcZones');
 const rankingRoutes = require('./routes/ranking');
 const orderTypePricesRoutes = require('./routes/orderTypePrices');
+const pointsDeVenteRoutes = require('./routes/pointsDeVente');
 
 const app = express();
 const PORT = process.env.BACKEND_PORT || 4000; 
@@ -105,6 +106,28 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
+// Route config PUBLIQUE : points de vente (table points_de_vente, éditable via l'UI).
+// Enregistrée AVANT les montages /api/v1 (dont attachmentRoutes applique authenticateToken à tout /api/v1),
+// afin de rester accessible sans authentification comme prévu pour une config publique — sinon les
+// dropdowns (chargés par un fetch non authentifié) ne verraient jamais les points ajoutés depuis l'UI.
+// Repli sur le JSON si la base est indisponible / la table absente.
+app.get('/api/v1/config/points-de-vente', async (req, res) => {
+  try {
+    const db = require('./models/database');
+    const { rows } = await db.query(
+      'SELECT value, label FROM points_de_vente WHERE is_active = true ORDER BY sort_order ASC, label ASC'
+    );
+    res.json({ points: rows });
+  } catch (err) {
+    console.error('Erreur config points-de-vente:', err);
+    try {
+      res.json(require('./config/points-de-vente.json'));
+    } catch (_) {
+      res.status(500).json({ error: 'Impossible de charger la configuration des points de vente' });
+    }
+  }
+});
+
 // Routes API
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/users', userRoutes);
@@ -121,6 +144,7 @@ app.use('/api/v1/timesheets', timesheetRoutes);
 app.use('/api/v1/versements', versementsRoutes);
 app.use('/api/v1/mlc-zones', mlcZonesRoutes);
 app.use('/api/v1/order-type-prices', orderTypePricesRoutes);
+app.use('/api/v1/points-de-vente', pointsDeVenteRoutes);
 app.use('/api/v1/ranking', rankingRoutes);
 app.use('/api/v1', attachmentRoutes);
 app.use('/api/external', externalRoutes);
@@ -134,16 +158,6 @@ app.get('/api/v1/config/order-types', (req, res) => {
     res.json(config);
   } catch (err) {
     res.status(500).json({ error: 'Impossible de charger la configuration des types de commandes' });
-  }
-});
-
-// Route config : points de vente (public, lu depuis points-de-vente.json)
-app.get('/api/v1/config/points-de-vente', (req, res) => {
-  try {
-    const config = require('./config/points-de-vente.json');
-    res.json(config);
-  } catch (err) {
-    res.status(500).json({ error: 'Impossible de charger la configuration des points de vente' });
   }
 });
 
@@ -315,6 +329,38 @@ async function runStartupMigrations() {
     console.log('✅ Migration: order_type_prices OK');
   } catch (err) {
     console.error('⚠️ Migration order_type_prices:', err.message);
+  }
+
+  // Table points_de_vente : points de vente MATA éditables depuis l'UI
+  try {
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS points_de_vente (
+        id SERIAL PRIMARY KEY,
+        value VARCHAR(200) NOT NULL UNIQUE,
+        label VARCHAR(200) NOT NULL,
+        sort_order INTEGER DEFAULT 0,
+        is_active BOOLEAN DEFAULT true,
+        created_at TIMESTAMP DEFAULT NOW(),
+        updated_at TIMESTAMP DEFAULT NOW()
+      )
+    `);
+    // Seed depuis points-de-vente.json si la table est vide (préserve l'ordre actuel)
+    const { rows } = await db.query('SELECT COUNT(*) FROM points_de_vente');
+    if (parseInt(rows[0].count) === 0) {
+      const pdvConfig = require('./config/points-de-vente.json');
+      let i = 1;
+      for (const p of pdvConfig.points) {
+        await db.query(
+          `INSERT INTO points_de_vente (value, label, sort_order) VALUES ($1, $2, $3)
+           ON CONFLICT (value) DO NOTHING`,
+          [p.value, p.label || p.value, i++]
+        );
+      }
+      console.log('✅ Migration: points_de_vente seeded');
+    }
+    console.log('✅ Migration: points_de_vente OK');
+  } catch (err) {
+    console.error('⚠️ Migration points_de_vente:', err.message);
   }
 
   // Mise à jour contrainte users_role_check pour inclure READONLY

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -8,8 +8,24 @@ const validOrderTypes = [
   ...orderTypesConfig.extensions.map(e => e.value)
 ];
 
-// Build valid points de vente from config
-const validPointsDeVente = pointsDeVenteConfig.points.map(p => p.value);
+// Accès DB pour valider dynamiquement le point de vente (pas de dépendance circulaire :
+// database.js n'importe pas validation.js).
+const db = require('../models/database');
+
+// Validation dynamique du point de vente contre la table points_de_vente (éditable via l'UI).
+// Accepte toute valeur EXISTANTE (active ou inactive) pour ne pas casser l'édition d'anciennes
+// commandes dont le point de vente a été désactivé depuis. Repli sur le JSON seed si la table
+// est absente / la base est indisponible.
+const pointDeVenteExists = async (value) => {
+  if (value == null || value === '') return true; // géré par .notEmpty()/.optional() en amont
+  try {
+    const { rows } = await db.query('SELECT 1 FROM points_de_vente WHERE value = $1 LIMIT 1', [value]);
+    if (rows.length > 0) return true;
+  } catch (e) {
+    if (pointsDeVenteConfig.points.some(p => p.value === value)) return true;
+  }
+  throw new Error('Point de vente invalide');
+};
 
 // Middleware pour gérer les erreurs de validation
 const handleValidationErrors = (req, res, next) => {
@@ -232,7 +248,8 @@ const validateOrderCreation = [
   body('point_de_vente')
     .if(body('order_type').equals('MATA'))
     .notEmpty().withMessage('Le point de vente est obligatoire pour MATA')
-    .isIn(validPointsDeVente).withMessage('Point de vente invalide'),
+    .bail()
+    .custom(pointDeVenteExists),
 
   body('created_at')
     .optional({ values: 'falsy' })
@@ -299,7 +316,7 @@ const validateOrderUpdate = [
   body('point_de_vente')
     .optional({ values: 'falsy' })
     .trim()
-    .isIn(validPointsDeVente).withMessage('Point de vente invalide'),
+    .custom(pointDeVenteExists),
 
   body('commentaire')
     .optional()

--- a/backend/routes/pointsDeVente.js
+++ b/backend/routes/pointsDeVente.js
@@ -1,0 +1,95 @@
+const express = require('express');
+const router = express.Router();
+const { authenticateToken, requireManagerOrAdmin, requireViewer } = require('../middleware/auth');
+const db = require('../models/database');
+
+// GET / — tous les utilisateurs authentifiés (pour les formulaires) : points actifs uniquement
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      'SELECT id, value, label, sort_order, is_active FROM points_de_vente WHERE is_active = true ORDER BY sort_order ASC, label ASC'
+    );
+    res.json({ points: rows });
+  } catch (err) {
+    console.error('Erreur GET points_de_vente:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /all — admin/viewer : inclut les points inactifs
+router.get('/all', authenticateToken, requireViewer, async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM points_de_vente ORDER BY sort_order ASC, label ASC');
+    res.json({ points: rows });
+  } catch (err) {
+    console.error('Erreur GET points_de_vente/all:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// POST / — créer un point de vente (manager/admin)
+router.post('/', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { value, label, sort_order } = req.body;
+    if (!value || !value.trim()) {
+      return res.status(400).json({ error: 'La valeur est requise' });
+    }
+    const v = value.trim();
+    const l = (label && label.trim()) ? label.trim() : v;
+    const { rows } = await db.query(
+      `INSERT INTO points_de_vente (value, label, sort_order) VALUES ($1, $2, $3) RETURNING *`,
+      [v, l, sort_order || 0]
+    );
+    res.status(201).json({ point: rows[0] });
+  } catch (err) {
+    if (err.code === '23505') {
+      return res.status(409).json({ error: 'Ce point de vente existe déjà' });
+    }
+    console.error('Erreur POST points_de_vente:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// PUT /:id — modifier (renommer / label / ordre / activer-désactiver) (manager/admin)
+router.put('/:id', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { value, label, sort_order, is_active } = req.body;
+    if (!value || !value.trim()) {
+      return res.status(400).json({ error: 'La valeur est requise' });
+    }
+    const v = value.trim();
+    const l = (label && label.trim()) ? label.trim() : v;
+    const { rows } = await db.query(
+      `UPDATE points_de_vente SET value=$1, label=$2, sort_order=$3, is_active=$4, updated_at=NOW() WHERE id=$5 RETURNING *`,
+      [v, l, sort_order || 0, is_active !== false, id]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Point de vente non trouvé' });
+    }
+    res.json({ point: rows[0] });
+  } catch (err) {
+    if (err.code === '23505') {
+      return res.status(409).json({ error: 'Ce point de vente existe déjà' });
+    }
+    console.error('Erreur PUT points_de_vente:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// DELETE /:id — supprimer (manager/admin)
+router.delete('/:id', authenticateToken, requireManagerOrAdmin, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await db.query('DELETE FROM points_de_vente WHERE id=$1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Point de vente non trouvé' });
+    }
+    res.json({ message: 'Point de vente supprimé' });
+  } catch (err) {
+    console.error('Erreur DELETE points_de_vente:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+module.exports = router;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -5902,3 +5902,12 @@ input[type="tel"]:focus {
 }
 
 /* ===== FIN STYLES VERSEMENTS ===== */
+
+/* Masquer les menus Suivi GPS, Analytics GPS et Mes Performances (demande client).
+   !important pour l'emporter sur le JS qui force display:flex sur ces items.
+   Réversible : supprimer ce bloc pour réafficher les menus. */
+#nav-gps-tracking,
+#nav-gps-analytics,
+#nav-my-performance {
+  display: none !important;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,6 +106,10 @@
                 <span class="icon">📍</span>
                 <span class="text">Zones MLC</span>
             </button>
+            <button class="nav-item hidden" id="nav-points-de-vente" data-page="points-de-vente">
+                <span class="icon">🏪</span>
+                <span class="text">Points de vente</span>
+            </button>
             <button class="nav-item hidden" id="nav-order-type-prices" data-page="order-type-prices">
                 <span class="icon">🏷️</span>
                 <span class="text">Prix des commandes</span>
@@ -1224,6 +1228,19 @@
             </div>
             <p style="color:#6c757d;margin:-20px 0 24px 4px;">Configurez les zones de livraison et leurs tarifs. Les livreurs verront ces zones lors de la creation d'une commande MLC.</p>
             <div id="mlc-zones-list">
+                <p style="text-align:center;padding:40px;color:#6c757d;">Chargement...</p>
+            </div>
+        </div>
+
+        <div id="points-de-vente-page" class="page">
+            <div class="page-header">
+                <h2>Gestion des Points de vente</h2>
+                <button class="btn btn-primary" id="add-pdv-btn" style="border-radius:10px;padding:10px 24px;font-weight:600;font-size:14px;display:flex;align-items:center;gap:8px;">
+                    <span style="font-size:18px;">+</span> Ajouter un point de vente
+                </button>
+            </div>
+            <p style="color:#6c757d;margin:-20px 0 24px 4px;">Configurez les points de vente MATA. Ils apparaissent dans les formulaires et filtres de commande. Désactiver masque un point de vente sans casser les commandes existantes ; renommer une valeur ne renomme PAS les commandes déjà enregistrées.</p>
+            <div id="points-de-vente-list">
                 <p style="text-align:center;padding:40px;color:#6c757d;">Chargement...</p>
             </div>
         </div>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -128,7 +128,19 @@ function populatePointsDeVenteSelects() {
       select.appendChild(opt);
     });
     const valueToApply = presetValue || previousValue;
-    if (valueToApply) select.value = valueToApply;
+    if (valueToApply) {
+      // Si la valeur courante (ex: commande existante dont le point de vente a été désactivé
+      // depuis) n'est pas dans la liste active, l'ajouter en option pour ne pas la perdre à
+      // l'édition — le backend accepte les valeurs existantes même inactives.
+      const exists = Array.from(select.options).some(o => o.value === valueToApply);
+      if (!exists) {
+        const opt = document.createElement('option');
+        opt.value = valueToApply;
+        opt.textContent = valueToApply + ' (inactif)';
+        select.appendChild(opt);
+      }
+      select.value = valueToApply;
+    }
   });
 }
 
@@ -919,6 +931,23 @@ class ApiClient {
     return this.request(`/mlc-zones/${id}`, { method: 'DELETE' });
   }
 
+  // Points de vente (éditables via l'UI)
+  static async getAllPointsDeVente() {
+    return this.request('/points-de-vente/all');
+  }
+
+  static async createPointDeVente(data) {
+    return this.request('/points-de-vente', { method: 'POST', body: JSON.stringify(data) });
+  }
+
+  static async updatePointDeVente(id, data) {
+    return this.request(`/points-de-vente/${id}`, { method: 'PUT', body: JSON.stringify(data) });
+  }
+
+  static async deletePointDeVente(id) {
+    return this.request(`/points-de-vente/${id}`, { method: 'DELETE' });
+  }
+
   // Prix par défaut des types de commandes (avec historisation)
   static async getCurrentOrderTypePrices() {
     return this.request('/order-type-prices/current');
@@ -1382,6 +1411,11 @@ class PageManager {
             await MlcZonesManager.loadZones();
           }
           break;
+        case 'points-de-vente':
+          if (AppState.user && (AppState.user.role === 'MANAGER' || AppState.user.role === 'ADMIN' || AppState.user.role === 'READONLY')) {
+            await PointsDeVenteManager.loadPoints();
+          }
+          break;
         case 'order-type-prices':
           if (AppState.user && (AppState.user.role === 'MANAGER' || AppState.user.role === 'ADMIN')) {
             await OrderTypePricesManager.loadPrices();
@@ -1574,6 +1608,13 @@ class AuthManager {
       if (navMlcZones) {
         navMlcZones.classList.remove('hidden');
         navMlcZones.style.display = 'flex';
+      }
+
+      // Affichage du menu Points de vente pour managers/admins/viewers
+      const navPointsDeVente = document.getElementById('nav-points-de-vente');
+      if (navPointsDeVente) {
+        navPointsDeVente.classList.remove('hidden');
+        navPointsDeVente.style.display = 'flex';
       }
 
       // Affichage du menu Prix des commandes : Manager/Admin uniquement (pas READONLY)
@@ -7129,6 +7170,124 @@ class MlcZonesManager {
         }
       }
     );
+  }
+}
+
+// ===== GESTIONNAIRE DES POINTS DE VENTE (éditables via l'UI) =====
+class PointsDeVenteManager {
+  static async loadPoints() {
+    const container = document.getElementById('points-de-vente-list');
+    if (!container) return;
+    const addBtn = document.getElementById('add-pdv-btn');
+    if (addBtn) addBtn.onclick = () => PointsDeVenteManager.showPointForm(null);
+    try {
+      const response = await ApiClient.getAllPointsDeVente();
+      const points = response.points || [];
+      if (points.length === 0) {
+        container.innerHTML = '<div style="text-align:center;padding:40px;color:#6c757d;">Aucun point de vente. Cliquez sur "Ajouter un point de vente".</div>';
+        return;
+      }
+      container.innerHTML = `
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:20px;">
+          ${points.map((p, i) => {
+            const color = MlcZonesManager.getZoneColor(i);
+            return `
+            <div style="background:white;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.08);overflow:hidden;${!p.is_active ? 'opacity:0.5;' : ''}">
+              <div style="background:${color.bg};color:${color.text};padding:20px;">
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <h3 style="margin:0;font-size:18px;font-weight:700;">${Utils.escapeHtml(p.value)}</h3>
+                  <span style="background:rgba(255,255,255,0.25);padding:4px 12px;border-radius:20px;font-size:12px;font-weight:600;">#${p.sort_order}</span>
+                </div>
+                <div style="font-size:14px;opacity:0.9;margin-top:6px;">${Utils.escapeHtml(p.label)}</div>
+              </div>
+              <div style="padding:16px;display:flex;justify-content:space-between;align-items:center;">
+                <span style="font-size:12px;padding:4px 10px;border-radius:12px;font-weight:600;${p.is_active ? 'background:#d4edda;color:#155724;' : 'background:#f8d7da;color:#721c24;'}">${p.is_active ? 'Actif' : 'Inactif'}</span>
+                <div style="display:flex;gap:8px;">
+                  <button class="btn btn-sm btn-primary edit-pdv-btn" data-id="${p.id}" style="border-radius:8px;font-size:12px;padding:6px 14px;">Modifier</button>
+                  <button class="btn btn-sm btn-danger delete-pdv-btn" data-id="${p.id}" style="border-radius:8px;font-size:12px;padding:6px 14px;">Supprimer</button>
+                </div>
+              </div>
+            </div>`;
+          }).join('')}
+          <div class="add-pdv-card" style="background:white;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.08);display:flex;align-items:center;justify-content:center;min-height:160px;cursor:pointer;border:3px dashed #dee2e6;">
+            <div style="text-align:center;color:#6c757d;"><div style="font-size:48px;line-height:1;margin-bottom:8px;color:#667eea;">+</div><div style="font-size:14px;font-weight:600;">Ajouter un point de vente</div></div>
+          </div>
+        </div>`;
+      const addCard = container.querySelector('.add-pdv-card');
+      if (addCard) addCard.addEventListener('click', () => PointsDeVenteManager.showPointForm(null));
+      container.querySelectorAll('.edit-pdv-btn').forEach(btn => btn.addEventListener('click', () => {
+        const p = points.find(x => x.id == btn.dataset.id);
+        if (p) PointsDeVenteManager.showPointForm(p);
+      }));
+      container.querySelectorAll('.delete-pdv-btn').forEach(btn => btn.addEventListener('click', () => PointsDeVenteManager.deletePoint(btn.dataset.id)));
+    } catch (err) {
+      console.error('Erreur chargement points de vente:', err);
+      container.innerHTML = '<p style="color:#dc3545;text-align:center;padding:20px;">Erreur lors du chargement.</p>';
+    }
+  }
+
+  static showPointForm(point) {
+    const isEdit = !!point;
+    ModalManager.show(isEdit ? 'Modifier le point de vente' : 'Ajouter un point de vente', `
+      <form id="pdv-form">
+        <div class="form-group">
+          <label>Nom / valeur *</label>
+          <input type="text" id="pdv-value" value="${isEdit ? Utils.escapeHtml(point.value) : ''}" required placeholder="Ex: Ngor">
+          ${isEdit ? '<small style="color:#6c757d;">Renommer la valeur ne modifie pas les commandes déjà enregistrées. Préférez désactiver.</small>' : ''}
+        </div>
+        <div class="form-group">
+          <label>Label affiché</label>
+          <input type="text" id="pdv-label" value="${isEdit ? Utils.escapeHtml(point.label) : ''}" placeholder="Par défaut = la valeur">
+        </div>
+        <div class="form-group">
+          <label>Ordre d'affichage</label>
+          <input type="number" id="pdv-sort-order" value="${isEdit ? point.sort_order : 0}" min="0">
+        </div>
+        ${isEdit ? `<div class="form-group"><label><input type="checkbox" id="pdv-active" ${point.is_active ? 'checked' : ''}> Actif</label></div>` : ''}
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary">${isEdit ? 'Enregistrer' : 'Ajouter'}</button>
+          <button type="button" class="btn btn-secondary" onclick="ModalManager.hide()">Annuler</button>
+        </div>
+      </form>`);
+    document.getElementById('pdv-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const value = document.getElementById('pdv-value').value.trim();
+      const label = document.getElementById('pdv-label').value.trim();
+      const data = { value, label: label || value, sort_order: parseInt(document.getElementById('pdv-sort-order').value) || 0 };
+      if (isEdit) {
+        const a = document.getElementById('pdv-active');
+        data.is_active = a ? a.checked : true;
+      }
+      try {
+        if (isEdit) {
+          await ApiClient.updatePointDeVente(point.id, data);
+          ToastManager.success('Point de vente modifié');
+        } else {
+          await ApiClient.createPointDeVente(data);
+          ToastManager.success('Point de vente ajouté');
+        }
+        ModalManager.hide();
+        await PointsDeVenteManager.loadPoints();
+        await loadPointsDeVenteConfig();   // rafraîchit les dropdowns en direct
+        populatePointsDeVenteSelects();
+      } catch (err) {
+        ToastManager.error(err.message || 'Erreur lors de la sauvegarde');
+      }
+    });
+  }
+
+  static async deletePoint(id) {
+    ModalManager.confirm('Supprimer le point de vente', 'Êtes-vous sûr ? Préférez désactiver si des commandes l\'utilisent.', async () => {
+      try {
+        await ApiClient.deletePointDeVente(id);
+        ToastManager.success('Point de vente supprimé');
+        await PointsDeVenteManager.loadPoints();
+        await loadPointsDeVenteConfig();
+        populatePointsDeVenteSelects();
+      } catch (err) {
+        ToastManager.error(err.message || 'Erreur lors de la suppression');
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## 1) Points de vente éditables via l'UI
Rend les points de vente configurables depuis l'interface (ajouter / renommer / activer-désactiver), **sans redéploiement**, en clonant le patron « Zones MLC ».

- **DB** : table `points_de_vente` créée + seedée au démarrage depuis `points-de-vente.json` (les 6 valeurs existantes).
- **CRUD** : `backend/routes/pointsDeVente.js` (`/api/v1/points-de-vente`, manager/admin ; doublon → 409).
- **Config** : `GET /api/v1/config/points-de-vente` lit désormais la base (repli JSON), et est **enregistrée avant les montages `/api/v1`** pour rester publique — sinon l'auth globale d'`attachmentRoutes` la bloquait (401) et les dropdowns ne voyaient jamais les ajouts.
- **Validation** : le `point_de_vente` des commandes MATA est validé **dynamiquement contre la base** (accepte les valeurs existantes, actives ou inactives) au lieu d'une liste JSON figée → les points ajoutés via l'UI sont acceptés ; un point désactivé n'empêche pas d'éditer une ancienne commande.
- **Frontend** : page admin « Points de vente » + menu + `PointsDeVenteManager` ; dropdowns rafraîchis après chaque modif ; à l'édition, un point désactivé reste sélectionnable (option « (inactif) »).

## 2) Masquage de 3 menus
Règle CSS masquant **Suivi GPS**, **Analytics GPS**, **Mes Performances** (réversible).

## Tests
Vérifié de bout en bout (migration/seed, CRUD API 201/409/404, config publique DB-backed, validation MATA accepte UI-added + rejette bidon, ajout via l'UI → dropdown mis à jour) et via Puppeteer. Revue adversariale : 1 défaut (édition d'un PDV désactivé) corrigé et vérifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Points de vente” management area in the app.
  * Users with the right access can now view, add, edit, and delete points de vente.
  * Existing selections remain available even if a point de vente is no longer active.

* **Bug Fixes**
  * Improved point de vente validation to better match the latest available data.
  * The app now shows inactive entries when needed instead of dropping them from selections.

* **Style**
  * Updated navigation visibility for selected menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->