### PR TITLE
fix: dates en fuseau Africa/Dakar + antidatage des commandes abonnement

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -628,7 +628,7 @@ class OrderController {
       orders.forEach(order => {
         worksheet.addRow({
           id: order.id,
-          created_at: new Date(order.created_at).toLocaleString('fr-FR'),
+          created_at: new Date(order.created_at).toLocaleString('fr-FR', { timeZone: 'Africa/Dakar', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }),
           creator_username: order.creator_username || 'N/A',
           client_name: order.client_name,
           phone_number: order.phone_number,
@@ -890,7 +890,7 @@ class OrderController {
       // Ajouter les données
       orders.forEach(order => {
         worksheet.addRow({
-          time: new Date(order.created_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' }),
+          time: new Date(order.created_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', timeZone: 'Africa/Dakar' }),
           client_name: order.client_name,
           phone_number: order.phone_number,
           address: order.address || '',
@@ -3172,7 +3172,7 @@ Réponds UNIQUEMENT en JSON valide, sans markdown.`;
       // Ajouter les données
       orders.forEach(order => {
         worksheet.addRow({
-          created_at: new Date(order.created_at).toLocaleString('fr-FR'),
+          created_at: new Date(order.created_at).toLocaleString('fr-FR', { timeZone: 'Africa/Dakar', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }),
           creator_username: order.creator_username || 'N/A',
           client_name: order.client_name,
           phone_number: order.phone_number,

--- a/backend/controllers/subscriptionController.js
+++ b/backend/controllers/subscriptionController.js
@@ -168,7 +168,7 @@ class SubscriptionController {
   // Créer une commande MLC avec déduction automatique
   static async createMLCOrderWithSubscription(req, res) {
     try {
-      const { client_name, phone_number, address, description, course_price, card_number, created_by } = req.body;
+      const { client_name, phone_number, address, description, course_price, card_number, created_by, created_at } = req.body;
       
       // Déterminer qui est le créateur de la commande
       let actualCreatedBy = req.user.id; // Par défaut, l'utilisateur connecté
@@ -232,6 +232,9 @@ class SubscriptionController {
         }
       }
 
+      // Seuls les managers/admins peuvent antidater (même règle que OrderController.createOrder)
+      const finalCreatedAt = (req.user.role === 'MANAGER' || req.user.role === 'ADMIN') && created_at ? created_at : undefined;
+
       // Créer la commande
       const order = await Order.create({
         client_name,
@@ -242,7 +245,8 @@ class SubscriptionController {
         course_price: course_price || 0,
         order_type: 'MLC',
         created_by: actualCreatedBy, // ✅ Utiliser le livreur assigné
-        subscription_id: subscription ? subscription.id : null
+        subscription_id: subscription ? subscription.id : null,
+        created_at: finalCreatedAt // ✅ Respecter la date de commande choisie (antidatage)
       });
 
       // Si une carte est trouvée, utiliser une livraison

--- a/backend/models/database.js
+++ b/backend/models/database.js
@@ -8,6 +8,10 @@ if (process.env.DATABASE_URL) {
   // Use connection string (common for Render)
   poolConfig = {
     connectionString: process.env.DATABASE_URL,
+    // Fuseau horaire métier: toute la logique de "jour" (DATE(created_at), TO_CHAR,
+    // CURRENT_DATE, backdate...) est calculée en Africa/Dakar (UTC+0, sans DST),
+    // indépendamment du fuseau du PC/serveur. Voir aussi frontend Utils.formatDate.
+    options: '-c timezone=Africa/Dakar',
     ssl: process.env.NODE_ENV === 'production' ? {
       rejectUnauthorized: false
     } : false,
@@ -23,6 +27,9 @@ if (process.env.DATABASE_URL) {
     database: process.env.DB_NAME || 'matix_livreur',
     user: process.env.DB_USER || 'matix_user',
     password: process.env.DB_PASSWORD || 'mlc2024',
+    // Fuseau horaire métier: le "jour" est calculé en Africa/Dakar (UTC+0),
+    // pas dans le fuseau local du PC (ex: Asia/Dubai) — corrige le filtrage par date.
+    options: '-c timezone=Africa/Dakar',
     max: 20,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 2000,

--- a/frontend/js/gps-tracking-manager.js
+++ b/frontend/js/gps-tracking-manager.js
@@ -909,7 +909,7 @@ class GpsTrackingManager {
         `;
 
         locationResponse.data.slice(0, 10).forEach(pos => {
-          const time = new Date(pos.timestamp).toLocaleTimeString();
+          const time = new Date(pos.timestamp).toLocaleTimeString('fr-FR', { timeZone: 'Africa/Dakar' });
           content += `
             <div style="margin-bottom: 5px; padding: 5px; background: #f5f5f5; border-radius: 3px;">
               ${time} - Lat: ${pos.latitude.toFixed(6)}, Lng: ${pos.longitude.toFixed(6)}
@@ -1107,7 +1107,7 @@ class GpsTrackingManager {
     startMarker.bindPopup(`
       <div>
         <strong>🏁 Départ</strong><br>
-        <small>${new Date(startPoint.timestamp).toLocaleTimeString()}</small><br>
+        <small>${new Date(startPoint.timestamp).toLocaleTimeString('fr-FR', { timeZone: 'Africa/Dakar' })}</small><br>
         <small>Précision: ${startPoint.accuracy}m</small>
       </div>
     `);
@@ -1129,7 +1129,7 @@ class GpsTrackingManager {
       endMarker.bindPopup(`
         <div>
           <strong>🏁 Arrivée</strong><br>
-          <small>${new Date(endPoint.timestamp).toLocaleTimeString()}</small><br>
+          <small>${new Date(endPoint.timestamp).toLocaleTimeString('fr-FR', { timeZone: 'Africa/Dakar' })}</small><br>
           <small>Précision: ${endPoint.accuracy}m</small>
         </div>
       `);
@@ -1155,7 +1155,7 @@ class GpsTrackingManager {
     document.getElementById('trace-avg-speed').textContent = `${summary.average_speed_kmh} km/h`;
     document.getElementById('trace-points-count').textContent = summary.total_points;
     
-    const timeRange = `${new Date(summary.start_time).toLocaleTimeString()} - ${new Date(summary.end_time).toLocaleTimeString()}`;
+    const timeRange = `${new Date(summary.start_time).toLocaleTimeString('fr-FR', { timeZone: 'Africa/Dakar' })} - ${new Date(summary.end_time).toLocaleTimeString('fr-FR', { timeZone: 'Africa/Dakar' })}`;
     document.getElementById('trace-time-range').textContent = timeRange;
     
     // Afficher le résumé

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -206,6 +206,7 @@ class Utils {
   static formatDate(dateString) {
     const date = new Date(dateString);
     return date.toLocaleDateString('fr-FR', {
+      timeZone: 'Africa/Dakar', // afficher les horodatages en heure de Dakar (UTC+0)
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
@@ -335,7 +336,9 @@ class Utils {
 
   static formatDisplayDate(dateString) { // YYYY-MM-DD to DD/MM/YYYY
     if (!dateString) return '';
-    const [year, month, day] = dateString.split('-');
+    // slice(0,10): tolère un timestamp ISO complet (ex: purchase_date/expiry_date
+    // renvoyés en timestamptz) — on prend la date UTC = date Dakar (UTC+0).
+    const [year, month, day] = String(dateString).slice(0, 10).split('-');
     return `${day}/${month}/${year}`;
   }
 }
@@ -2226,7 +2229,7 @@ class DashboardManager {
                 <tbody>
                   ${orders.map(order => `
                     <tr>
-                      <td>${new Date(order.created_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}</td>
+                      <td>${new Date(order.created_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', timeZone: 'Africa/Dakar' })}</td>
                       <td>${Utils.escapeHtml(order.client_name)}
                         ${order.interne ? '<span class="badge-internal" style="background:#dc2626;color:#fff;padding:2px 6px;border-radius:6px;font-size:0.7em;margin-left:4px;">🏢</span>' : ''}
                       </td>
@@ -4165,6 +4168,20 @@ class OrderManager {
     }
   }
 
+  // Recharger la liste en conservant les filtres actifs (date/livreur/type).
+  // Utilisé après une modification/suppression pour éviter que la vue ne
+  // "saute" vers les commandes récentes (la date affichée ne doit pas changer).
+  static async refreshOrdersView() {
+    const dateFilter = document.getElementById('orders-date-filter')?.value;
+    const livreurFilter = document.getElementById('orders-livreur-filter')?.value;
+    const typeFilter = document.getElementById('orders-type-filter')?.value;
+    if (dateFilter || livreurFilter || typeFilter) {
+      await this.loadOrdersWithFilters();
+    } else {
+      await this.loadOrders(AppState.currentOrdersPage);
+    }
+  }
+
   static async loadOrdersByDate(date) {
     try {
       const response = await ApiClient.getOrdersByDate(date);
@@ -4936,7 +4953,7 @@ class OrderManager {
           await ApiClient.updateOrder(orderId, orderData);
           ModalManager.hide();
           ToastManager.success('Commande modifiée avec succès');
-          await this.loadOrders(AppState.currentOrdersPage);
+          await this.refreshOrdersView();
         } catch (error) {
           ToastManager.error(error.message || 'Erreur lors de la modification');
         }
@@ -4951,7 +4968,7 @@ class OrderManager {
     try {
       await ApiClient.deleteOrder(orderId);
       ToastManager.success('Commande supprimée avec succès');
-      await this.loadOrders(AppState.currentOrdersPage);
+      await this.refreshOrdersView();
       // Rafraîchir la liste des abonnements si la page active est 'subscriptions'
       if (AppState.currentPage === 'subscriptions') {
         await SubscriptionManager.loadSubscriptions();
@@ -9117,8 +9134,8 @@ class ContactManager {
     }
 
     container.innerHTML = clients.map(client => {
-      const lastOrderDate = client.last_order_date ? 
-        new Date(client.last_order_date).toLocaleDateString('fr-FR') : 'Jamais';
+      const lastOrderDate = client.last_order_date ?
+        new Date(client.last_order_date).toLocaleDateString('fr-FR', { timeZone: 'Africa/Dakar' }) : 'Jamais';
       
       return `
         <div class="client-item" data-phone="${client.phone_number}" data-name="${client.client_name}">

--- a/frontend/js/mlc-table.js
+++ b/frontend/js/mlc-table.js
@@ -555,7 +555,7 @@ class MlcTableManager {
     // Créer une ligne de détail de commande
     static createOrderDetailRow(order) {
         const orderDate = new Date(order.created_at);
-        const dateTime = `${Utils.formatDisplayDate(orderDate.toISOString().split('T')[0])} ${orderDate.toLocaleTimeString()}`;
+        const dateTime = `${Utils.formatDisplayDate(orderDate.toISOString().split('T')[0])} ${orderDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', timeZone: 'Africa/Dakar' })}`;
         
         const orderType = order.subscription_id ? 'MLC Abonnement' : 'MLC Simple';
         const hasSupplement = order.has_supplement ? 'Oui' : 'Non';


### PR DESCRIPTION
## Contexte
Le PC de dev tourne en **Asia/Dubai (UTC+4)** alors que le métier est à **Dakar (UTC+0)**. Résultat : une commande créée à `20:28 UTC` s'affichait `22/07 00:28` mais était rangée dans un autre bucket de jour, et le filtre par date ne correspondait pas à l'affichage.

## Correctifs

### 1. Fuseau métier épinglé sur Africa/Dakar
- **`backend/models/database.js`** : le pool partagé force `timezone=Africa/Dakar`. Tout le bucketing SQL par jour/mois sur les colonnes `timestamptz` (`DATE(created_at)`, filtres, `TO_CHAR`, `CURRENT_DATE`) est désormais calculé en heure de Dakar, quel que soit le fuseau du PC/serveur. **Aucun impact en prod** (Render tourne en UTC ≡ Dakar).
- **Frontend** : affichage des horodatages en Africa/Dakar (`Utils.formatDate` central + sites inline : détails commande, table MLC, traces GPS). `formatDisplayDate` durci pour tolérer un timestamp ISO complet.

### 2. Antidatage des commandes d'abonnement (le vrai bug remonté)
- **`backend/controllers/subscriptionController.js`** : la route `/subscriptions/mlc-order` ignorait le champ « Date de la commande » et forçait `NOW()`. Elle transmet maintenant `created_at` à `Order.create` avec la même règle que les commandes normales (antidatage réservé aux managers/admins).

### 3. UX liste des commandes
- **`frontend/js/main.js`** : après une modification/suppression, la liste conserve les filtres actifs au lieu de sauter vers les commandes du jour.

## Vérifications (base locale `mlc_db`)
- Session du pool = `Africa/Dakar`.
- `findByDate('2026-07-21')` renvoie bien les commandes de 20:xx UTC ; `findByDate('2026-07-22')` → 0.
- Un abonnement antidaté au `2026-07-16` est stocké/affiché au **16/07 00:00** et apparaît sous le filtre 16/07 (pas 19/07).

## Suites possibles (hors périmètre, non incluses)
- Colonnes `timestamp` **sans** fuseau (timesheets, audit, client_credits, commandes_en_cours) : bucketing/affichage encore en heure murale serveur — nécessite une migration avant d'y toucher (risque de double décalage).
- Bugs `toISOString()` sur colonnes `date` (`versementsController.js:197`, `Expense.js:240`, `orderController.js:2880`) et bornes de mois via `getMonth()` local (`routes/external.js`, `mataAnalyticsController.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized date and time displays across dashboards, GPS tracking, order tables, contact details, and Excel exports using the Africa/Dakar timezone.
  * Order updates and deletions now preserve active filters and keep the current view stable.
  * Daily trace and delivery timestamps provide clearer, consistent French-localized formatting.

* **Access Control**
  * Managers and administrators can set an order’s historical creation date when creating subscription orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->