### PR TITLE
feat: envoi WhatsApp facultatif pour les commandes MLC avec abonnement

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -8071,8 +8071,9 @@ class App {
         }
         // Afficher le bouton WhatsApp (envoi facultatif)
         if (whatsappBtn) whatsappBtn.style.display = 'inline-flex';
-        // WhatsApp facultatif : ne PAS bloquer la creation de la commande
-        if (submitBtn) {
+        // WhatsApp facultatif : ne PAS bloquer la creation de la commande.
+        // Ne pas réactiver si une soumission est déjà en cours (évite le double envoi).
+        if (submitBtn && submitBtn.dataset.submitting !== 'true') {
           submitBtn.disabled = false;
           submitBtn.style.opacity = '';
           submitBtn.style.cursor = '';
@@ -8081,7 +8082,8 @@ class App {
       } else {
         if (whatsappBtn) whatsappBtn.style.display = 'none';
         // Reactiver le bouton si l'abonnement est deselectionne
-        if (submitBtn) {
+        // (sauf si une soumission est en cours).
+        if (submitBtn && submitBtn.dataset.submitting !== 'true') {
           submitBtn.disabled = false;
           submitBtn.style.opacity = '';
           submitBtn.style.cursor = '';
@@ -8132,8 +8134,9 @@ class App {
           window.open(whatsappUrl, '_blank');
           ModalManager.hide();
           // Reactiver le bouton Creer la commande apres envoi WhatsApp
+          // (sauf si une soumission est deja en cours).
           const submitBtn = document.getElementById('submit-order-btn');
-          if (submitBtn) {
+          if (submitBtn && submitBtn.dataset.submitting !== 'true') {
             submitBtn.disabled = false;
             submitBtn.style.opacity = '';
             submitBtn.style.cursor = '';
@@ -8220,6 +8223,9 @@ class App {
       }
       
       // Désactiver le bouton et afficher le spinner
+      // Marqueur de soumission: empêche les autres handlers (sélection d'abonnement,
+      // envoi WhatsApp) de réactiver le bouton tant que la requête est en cours.
+      submitBtn.dataset.submitting = 'true';
       submitBtn.disabled = true;
       submitBtn.style.opacity = '0.6';
       submitBtn.style.cursor = 'not-allowed';
@@ -8230,6 +8236,7 @@ class App {
       
       // Fonction pour réactiver le bouton
       const resetButton = () => {
+        delete submitBtn.dataset.submitting;
         submitBtn.disabled = false;
         submitBtn.style.opacity = '1';
         submitBtn.style.cursor = 'pointer';

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -8069,14 +8069,14 @@ class App {
           const coursePrice = Math.round(price / totalDeliveries);
           document.getElementById('course-price').value = coursePrice;
         }
-        // Afficher le bouton WhatsApp
+        // Afficher le bouton WhatsApp (envoi facultatif)
         if (whatsappBtn) whatsappBtn.style.display = 'inline-flex';
-        // Desactiver le bouton Creer la commande tant que WhatsApp n'est pas envoye
+        // WhatsApp facultatif : ne PAS bloquer la creation de la commande
         if (submitBtn) {
-          submitBtn.disabled = true;
-          submitBtn.style.opacity = '0.5';
-          submitBtn.style.cursor = 'not-allowed';
-          submitBtn.title = 'Envoyez d\'abord le WhatsApp au client';
+          submitBtn.disabled = false;
+          submitBtn.style.opacity = '';
+          submitBtn.style.cursor = '';
+          submitBtn.title = '';
         }
       } else {
         if (whatsappBtn) whatsappBtn.style.display = 'none';


### PR DESCRIPTION
## Contexte
Sur une commande **MLC avec abonnement**, sélectionner la carte désactivait le bouton **« Créer la commande »** jusqu'à ce que le message WhatsApp soit envoyé (gate front-end, tooltip *« Envoyez d'abord le WhatsApp au client »*).

## Changement
L'envoi WhatsApp devient **facultatif** :
- Le bouton WhatsApp reste affiché (on peut toujours envoyer la notification si on le souhaite).
- Le bouton **« Créer la commande » n'est plus bloqué** : la commande peut être créée avec ou sans envoi WhatsApp.

Un seul fichier touché : `frontend/js/main.js` (handler de sélection d'abonnement). Aucun changement back-end (le gate était uniquement côté client).

## Test (local, UI)
Testé sur l'environnement local (login MANAGER, Nouvelle commande → MLC → Utiliser un abonnement → sélection d'une carte) :
- `submit-order-btn.disabled` = **false** (bouton actif), tooltip vide, plus de style grisé.
- Bouton WhatsApp toujours visible (`display: flex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription-based MLC orders can now be created without sending a WhatsApp notification.
  * The WhatsApp option remains available, and sending a message continues to re-enable the order button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->